### PR TITLE
[JENKINS-26585] - Two new variants to show also direct link to job witho...

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/badge/BadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/BadgeAction/index.groovy
@@ -30,44 +30,79 @@ l.layout {
 </style>
 """)
 
-        def base =  "${app.rootUrl}${my.project.url}";
-        def badge = base + "badge/icon"
-        
         def fullJobName = h.escape(my.project.fullName);
-        def publicbadge = "${app.rootUrl}buildStatus/icon?job=${fullJobName}";
+        def jobUrlWithView =  "${app.rootUrl}${my.project.url}";
+        def jobUrlWithoutView =  "${app.rootUrl}job/${fullJobName}";
+        def badgeUrlWithView = jobUrlWithView + "badge/icon"
+        def badgeUrlWithoutView = jobUrlWithoutView + "/badge/icon"
+        def publicBadge = "${app.rootUrl}buildStatus/icon?job=${fullJobName}";
+
+
         h3 {
             text(_("Image"))
-            img(id:"badge",src:badge)
+            img(id:"badgeUrlWithView",src:badgeUrlWithView)
             text(_(" or "))
-            img(src:badge + "?style=plastic")
+            img(src:badgeUrlWithView + "?style=plastic")
         }
-        b {text(_("protected"))}
-        input(type:"text",value:badge,class:"select-all")
-        b {text(_("unprotected"))}
-        input(type:"text",value:publicbadge,class:"select-all")
 
-        h3(_("Markdown"))
+        h3(_("Plain Link (with view)"))
         b {text(_("protected"))}
-        input(type:"text",value:"[![Build Status](${badge})](${base})",class:"select-all")
+        input(type:"text",value:badgeUrlWithView,class:"select-all")
         b {text(_("unprotected"))}
-        input(type:"text",value:"[![Build Status](${publicbadge})](${base})",class:"select-all")
+        input(type:"text",value:publicBadge,class:"select-all")
 
-        h3(_("HTML"))
+        h3(_("Plain Link (without view)"))
         b {text(_("protected"))}
-        input(type:"text",value:"<a href='${base}'><img src='${badge}'></a>",class:"select-all")
+        input(type:"text",value:badgeUrlWithoutView,class:"select-all")
         b {text(_("unprotected"))}
-        input(type:"text",value:"<a href='${base}'><img src='${publicbadge}'></a>",class:"select-all")
+        input(type:"text",value:publicBadge,class:"select-all")
 
-        h3(_("Confluence"))
+        h3(_("Markdown (with view)"))
         b {text(_("protected"))}
-        input(type:"text",value:"[!${badge}!|${base}]",class:"select-all")
+        input(type:"text",value:"[![Build Status](${badgeUrlWithView})](${jobUrlWithView})",class:"select-all")
         b {text(_("unprotected"))}
-        input(type:"text",value:"[!${publicbadge}!|${base}]",class:"select-all")
+        input(type:"text",value:"[![Build Status](${publicBadge})](${jobUrlWithView})",class:"select-all")
 
-        h3(_("XWiki"))
+        h3(_("Markdown (without view)"))
         b {text(_("protected"))}
-        input(type:"text",value:"[[image:${badge}>>${base}||target='__new']]",class:"select-all")
+        input(type:"text",value:"[![Build Status](${badgeUrlWithoutView})](${jobUrlWithoutView})",class:"select-all")
         b {text(_("unprotected"))}
-        input(type:"text",value:"[[image:${publicbadge}>>${base}||target='__new']]",class:"select-all")
+        input(type:"text",value:"[![Build Status](${publicBadge})](${jobUrlWithoutView})",class:"select-all")
+
+        h3(_("HTML (with view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"<a href='${jobUrlWithView}'><img src='${badgeUrlWithView}'></a>",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"<a href='${jobUrlWithView}'><img src='${publicBadge}'></a>",class:"select-all")
+
+        h3(_("HTML (without view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"<a href='${jobUrlWithoutView}'><img src='${badgeUrlWithoutView}'></a>",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"<a href='${jobUrlWithoutView}'><img src='${publicBadge}'></a>",class:"select-all")
+
+        h3(_("Confluence (with view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"[!${badgeUrlWithView}!|${jobUrlWithView}]",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"[!${publicBadge}!|${jobUrlWithView}]",class:"select-all")
+
+        h3(_("Confluence (without view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"[!${badgeUrlWithoutView}!|${jobUrlWithoutView}]",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"[!${publicBadge}!|${jobUrlWithoutView}]",class:"select-all")
+
+        h3(_("XWiki (with view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"[[image:${badgeUrlWithView}>>${jobUrlWithView}||target='__new']]",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"[[image:${publicBadge}>>${jobUrlWithView}||target='__new']]",class:"select-all")
+
+        h3(_("XWiki (without view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"[[image:${badgeUrlWithoutView}>>${jobUrlWithoutView}||target='__new']]",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"[[image:${publicBadge}>>${jobUrlWithoutView}||target='__new']]",class:"select-all")
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/badge/BadgeAction/index.properties
+++ b/src/main/resources/org/jenkinsci/plugins/badge/BadgeAction/index.properties
@@ -1,6 +1,11 @@
 blurb=Jenkins exposes the current status of your build as an image in a fixed URL. \
       You can put this URL into other sites (such as GitHub README) so that people \
-      can see the current state of the build. <br>There are two URLs available for inclusion: <br> \
+      can see the current state of the build. <br>There are two variants available for inclusion: <br> \
+      <ul>  \
+        <li><b>with view</b> includes the current view into the URL.</li> \
+        <li><b>without view</b> contains the direct path to the job excluding the current view</li> \
+      </ul> \
+      <br>For each variant there are two URLs available for inclusion: <br> \
       <ul>  \
        <li><b>protected</b> exposes the badge to users having at least 'Read' permission on the job</li> \
        <li><b>unprotected</b> exposes the badge to users having at least 'ViewStatus' permission on the job</li> \

--- a/src/main/resources/org/jenkinsci/plugins/badge/RunBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/RunBadgeAction/index.groovy
@@ -30,44 +30,79 @@ l.layout {
 </style>
 """)
 
-        def base =  "${app.rootUrl}${my.project.url}${my.run.number}/";
-        def badge = base + "badge/icon"
-        
         def fullJobName = h.escape(my.project.fullName);
-        def publicbadge = "${app.rootUrl}buildStatus/icon?job=${fullJobName}&build=${my.run.number}";
+        def jobUrlWithView =  "${app.rootUrl}${my.project.url}${my.run.number}/";
+        def jobUrlWithoutView =  "${app.rootUrl}job/${fullJobName}/${my.run.number}/";
+        def badgeUrlWithView = jobUrlWithView + "badge/icon"
+        def badgeUrlWithoutView = jobUrlWithoutView + "/badge/icon"
+        def publicBadge = "${app.rootUrl}buildStatus/icon?job=${fullJobName}&build=${my.run.number}";
+
         h3 {
             text(_("Image"))
-            img(id:"badge",src:badge)
+            img(id:"badgeUrlWithView",src:badgeUrlWithView)
             text(_(" or "))
-            img(src:badge + "?style=plastic")
+            img(src:badgeUrlWithView + "?style=plastic")
         }
-        b {text(_("protected"))}
-        input(type:"text",value:badge,class:"select-all")
-        b {text(_("unprotected"))}
-        input(type:"text",value:publicbadge,class:"select-all")
 
-        h3(_("Markdown"))
+        h3(_("Plain Link (with view)"))
         b {text(_("protected"))}
-        input(type:"text",value:"[![Build Status](${badge})](${base})",class:"select-all")
+        input(type:"text",value:badgeUrlWithView,class:"select-all")
         b {text(_("unprotected"))}
-        input(type:"text",value:"[![Build Status](${publicbadge})](${base})",class:"select-all")
+        input(type:"text",value:publicBadge,class:"select-all")
 
-        h3(_("HTML"))
+        h3(_("Plain Link (without view)"))
         b {text(_("protected"))}
-        input(type:"text",value:"<a href='${base}'><img src='${badge}'></a>",class:"select-all")
+        input(type:"text",value:badgeUrlWithoutView,class:"select-all")
         b {text(_("unprotected"))}
-        input(type:"text",value:"<a href='${base}'><img src='${publicbadge}'></a>",class:"select-all")
+        input(type:"text",value:publicBadge,class:"select-all")
 
-        h3(_("Confluence"))
-        b {text(_("protected"))}
-        input(type:"text",value:"[!${badge}!|${base}]",class:"select-all")
-        b {text(_("unprotected"))}
-        input(type:"text",value:"[!${publicbadge}!|${base}]",class:"select-all")
 
-        h3(_("XWiki"))
+        h3(_("Markdown (with view)"))
         b {text(_("protected"))}
-        input(type:"text",value:"[[image:${badge}>>${base}||target='__new']]",class:"select-all")
+        input(type:"text",value:"[![Build Status](${badgeUrlWithView})](${jobUrlWithView})",class:"select-all")
         b {text(_("unprotected"))}
-        input(type:"text",value:"[[image:${publicbadge}>>${base}||target='__new']]",class:"select-all")
+        input(type:"text",value:"[![Build Status](${publicBadge})](${jobUrlWithView})",class:"select-all")
+
+        h3(_("Markdown (without view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"[![Build Status](${badgeUrlWithoutView})](${jobUrlWithoutView})",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"[![Build Status](${publicBadge})](${jobUrlWithoutView})",class:"select-all")
+
+        h3(_("HTML (with view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"<a href='${jobUrlWithView}'><img src='${badgeUrlWithView}'></a>",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"<a href='${jobUrlWithView}'><img src='${publicBadge}'></a>",class:"select-all")
+
+        h3(_("HTML (without view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"<a href='${jobUrlWithoutView}'><img src='${badgeUrlWithoutView}'></a>",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"<a href='${jobUrlWithoutView}'><img src='${publicBadge}'></a>",class:"select-all")
+
+        h3(_("Confluence (with view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"[!${badgeUrlWithView}!|${jobUrlWithView}]",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"[!${publicBadge}!|${jobUrlWithView}]",class:"select-all")
+
+        h3(_("Confluence (without view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"[!${badgeUrlWithoutView}!|${jobUrlWithoutView}]",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"[!${publicBadge}!|${jobUrlWithoutView}]",class:"select-all")
+
+        h3(_("XWiki (with view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"[[image:${badgeUrlWithView}>>${jobUrlWithView}||target='__new']]",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"[[image:${publicBadge}>>${jobUrlWithView}||target='__new']]",class:"select-all")
+
+        h3(_("XWiki (without view)"))
+        b {text(_("protected"))}
+        input(type:"text",value:"[[image:${badgeUrlWithoutView}>>${jobUrlWithoutView}||target='__new']]",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"[[image:${publicBadge}>>${jobUrlWithoutView}||target='__new']]",class:"select-all")
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/badge/RunBadgeAction/index.properties
+++ b/src/main/resources/org/jenkinsci/plugins/badge/RunBadgeAction/index.properties
@@ -1,6 +1,11 @@
 blurb=Jenkins exposes the status of the specific build as an image in a fixed URL. \
       You can put this URL into other sites (such as GitHub README) so that people \
-      can see the state of the specific build. <br>There are two URLs available for inclusion: <br> \
+      can see the state of the specific build. <br>There are two variants available for inclusion: <br> \
+      <ul>  \
+       <li><b>with view</b> includes the current view into the URL.</li> \
+       <li><b>without view</b> contains the direct path to the build excluding the current view</li> \
+      </ul> \
+      <br>For each variant there are two URLs available for inclusion: <br> \
       <ul>  \
        <li><b>protected</b> exposes the badge to users having at least 'Read' permission on the job</li> \
        <li><b>unprotected</b> exposes the badge to users having at least 'ViewStatus' permission on the job</li> \


### PR DESCRIPTION
Added for each output format a variant with and without view path in the URL. This keeps backwards compatibility and users can choose which URL to choose.