### PR TITLE
Fixed ETag header

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
@@ -41,7 +41,7 @@ class StatusImage implements HttpResponse {
     private final String length;
 
     StatusImage(String fileName) throws IOException {
-        etag = Jenkins.RESOURCE_PATH+'/'+fileName;
+        etag = '"' + Jenkins.RESOURCE_PATH + '/' + fileName + '"';
 
         URL image = new URL(
             Jenkins.getInstance().pluginManager.getPlugin("embeddable-build-status").baseResourceURL,


### PR DESCRIPTION
According to RFC 7232, an ETag header must be a quoted string.

http://tools.ietf.org/html/rfc7232#section-2.3

Client libraries with strictly typed header handling (like Rust's [hyper](http://hyper.rs/hyper/hyper/header/struct.EntityTag.html)) will therefore consider an ETag without quotes invalid.