### PR TITLE
[JENKINS-19319] Distinguish between Aborted and Failed in the status icon

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/ImageResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/ImageResolver.java
@@ -41,6 +41,7 @@ public class ImageResolver {
                 new StatusImage("build-unstable-yellow.svg"),
                 new StatusImage("build-passing-brightgreen.svg"),
                 new StatusImage("build-running-blue.svg"),
+                new StatusImage("build-aborted-lightgrey.svg"),
                 new StatusImage("build-unknown-lightgrey.svg")
         };
         styles.put("plastic", plasticImages);
@@ -50,6 +51,7 @@ public class ImageResolver {
                 new StatusImage("build-unstable-yellow-flat.svg"),
                 new StatusImage("build-passing-brightgreen-flat.svg"),
                 new StatusImage("build-running-blue-flat.svg"),
+                new StatusImage("build-aborted-lightgrey-flat.svg"),
                 new StatusImage("build-unknown-lightgrey-flat.svg")
         };
         styles.put("flat", flatImages);
@@ -72,14 +74,15 @@ public class ImageResolver {
 
         switch (color) {
         case RED:
-        case ABORTED:
             return images[0];
         case YELLOW:
             return images[1];
         case BLUE:
             return images[2];
+        case ABORTED:
+			return images[4];
         default:
-            return images[4];
+            return images[5];
         }
     }
 

--- a/src/main/webapp/status/build-aborted-lightgrey-flat.svg
+++ b/src/main/webapp/status/build-aborted-lightgrey-flat.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="98" height="20">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <rect rx="3" width="98" height="20" fill="#555"/>
+  <rect rx="3" x="37" width="61" height="20" fill="#9f9f9f"/>
+  <path fill="#9f9f9f" d="M37 0h4v20h-4z"/>
+  <rect rx="3" width="98" height="20" fill="url(#a)"/>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="19.5" y="15" fill="#010101" fill-opacity=".3">build</text>
+    <text x="19.5" y="14">build</text>
+    <text x="66.5" y="15" fill="#010101" fill-opacity=".3">aborted</text>
+    <text x="66.5" y="14">aborted</text>
+  </g>
+</svg>

--- a/src/main/webapp/status/build-aborted-lightgrey.svg
+++ b/src/main/webapp/status/build-aborted-lightgrey.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="98" height="18">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-opacity=".3"/>
+    <stop offset="1" stop-opacity=".5"/>
+  </linearGradient>
+  <rect rx="4" width="98" height="18" fill="#555"/>
+  <rect rx="4" x="37" width="61" height="18" fill="#9f9f9f"/>
+  <path fill="#9f9f9f" d="M37 0h4v18h-4z"/>
+  <rect rx="4" width="98" height="18" fill="url(#a)"/>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="19.5" y="13" fill="#010101" fill-opacity=".3">build</text>
+    <text x="19.5" y="12">build</text>
+    <text x="66.5" y="13" fill="#010101" fill-opacity=".3">aborted</text>
+    <text x="66.5" y="12">aborted</text>
+  </g>
+</svg>


### PR DESCRIPTION
suggested solution for: JENKINS-19319 Distinguish between Aborted and Failed in the status icon

https://issues.jenkins-ci.org/browse/JENKINS-19319

I added two new svg images to be able to distinguish between failed and aborted jobs.
The images are exact copies of the already existing unknown images, only changed the unknown text to aborted.

In the ImageResolver I added the two new filenames to the two existing styles.
I've added them in the second to last place because it seemed logical to me to have the image of the default case , which is "unknown", still at the last slot.

I did not touch are add any test for this change.