### PR TITLE
New endpoint 'text' to return icon description

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/BadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/BadgeAction.java
@@ -38,4 +38,11 @@ public class BadgeAction implements Action {
     public HttpResponse doIcon(@QueryParameter String style) {
         return factory.getImage(project.getIconColor(), style);
     }
+
+    /**
+     * Serves text.
+     */
+    public String doText() {
+        return project.getIconColor().getDescription();
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/badge/PublicBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/PublicBadgeAction.java
@@ -100,6 +100,19 @@ public class PublicBadgeAction implements UnprotectedRootAction {
         }
     }
 
+    /**
+     * Serves text.
+     */
+    public String doText(StaplerRequest req, StaplerResponse rsp, @QueryParameter String job, @QueryParameter String build) {
+        if(build != null) {
+            Run run = getRun(job, build);
+            return run.getIconColor().getDescription();
+        } else {
+            Job<?, ?> project = getProject(job);
+            return project.getIconColor().getDescription();
+        }
+    }
+
     private Job<?, ?> getProject(String job) {
         Job<?, ?> p;
 

--- a/src/main/java/org/jenkinsci/plugins/badge/RunBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/RunBadgeAction.java
@@ -36,4 +36,11 @@ public class RunBadgeAction implements Action {
     public HttpResponse doIcon(@QueryParameter String style) {
         return factory.getImage(run.getIconColor(), style);
     }
+
+    /**
+     * Serves text.
+     */
+    public String doText() {
+        return project.getIconColor().getDescription();
+    }
 }

--- a/src/main/resources/org/jenkinsci/plugins/badge/BadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/BadgeAction/index.groovy
@@ -35,7 +35,10 @@ l.layout {
         def jobUrlWithoutView =  "${app.rootUrl}job/${fullJobName}";
         def badgeUrlWithView = jobUrlWithView + "badge/icon"
         def badgeUrlWithoutView = jobUrlWithoutView + "/badge/icon"
+        def textUrlWithView = jobUrlWithView + "badge/text"
+        def textUrlWithoutView = jobUrlWithoutView + "/badge/text"
         def publicBadge = "${app.rootUrl}buildStatus/icon?job=${fullJobName}";
+        def publicText = "${app.rootUrl}buildStatus/text?job=${fullJobName}";
 
 
         h3 {
@@ -104,5 +107,17 @@ l.layout {
         input(type:"text",value:"[[image:${badgeUrlWithoutView}>>${jobUrlWithoutView}||target='__new']]",class:"select-all")
         b {text(_("unprotected"))}
         input(type:"text",value:"[[image:${publicBadge}>>${jobUrlWithoutView}||target='__new']]",class:"select-all")
+
+
+        h2(_("Embeddable Build Status Text"))
+        p(raw(_("blurb_text")))
+
+        h3(_("Text Only"))
+        b {text(_("protected (with view)"))}
+        input(type:"text",value:textUrlWithView,class:"select-all")
+        b {text(_("protected (without view)"))}
+        input(type:"text",value:textUrlWithoutView,class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:publicText,class:"select-all")
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/badge/BadgeAction/index.properties
+++ b/src/main/resources/org/jenkinsci/plugins/badge/BadgeAction/index.properties
@@ -17,3 +17,6 @@ blurb=Jenkins exposes the current status of your build as an image in a fixed UR
         <li><b>plastic</b> (the one used in version 1.5)\
       </ul> \
       You can choose the one you prefer by appending <tt>?style=plastic</tt> to the URL.
+blurb_text=Jenkins also exposes the current status of your build in plain text. \
+      You can use this in external scripts for easier interpretation of the current state of the build. \
+      Similar to the badge there are both <b>with view</b> and <b>without view</b> for <b>protected</b>, as well as <b>unprotected</b> variants.

--- a/src/main/resources/org/jenkinsci/plugins/badge/RunBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/RunBadgeAction/index.groovy
@@ -35,7 +35,10 @@ l.layout {
         def jobUrlWithoutView =  "${app.rootUrl}job/${fullJobName}/${my.run.number}/";
         def badgeUrlWithView = jobUrlWithView + "badge/icon"
         def badgeUrlWithoutView = jobUrlWithoutView + "/badge/icon"
+        def textUrlWithView = jobUrlWithView + "badge/text"
+        def textUrlWithoutView = jobUrlWithoutView + "/badge/text"
         def publicBadge = "${app.rootUrl}buildStatus/icon?job=${fullJobName}&build=${my.run.number}";
+        def publicText = "${app.rootUrl}buildStatus/text?job=${fullJobName}&build=${my.run.number}";
 
         h3 {
             text(_("Image"))
@@ -104,5 +107,17 @@ l.layout {
         input(type:"text",value:"[[image:${badgeUrlWithoutView}>>${jobUrlWithoutView}||target='__new']]",class:"select-all")
         b {text(_("unprotected"))}
         input(type:"text",value:"[[image:${publicBadge}>>${jobUrlWithoutView}||target='__new']]",class:"select-all")
+
+
+        h2(_("Embeddable Build Status Text"))
+        p(raw(_("blurb_text")))
+
+        h3(_("Text Only"))
+        b {text(_("protected (with view)"))}
+        input(type:"text",value:textUrlWithView,class:"select-all")
+        b {text(_("protected (without view)"))}
+        input(type:"text",value:textUrlWithoutView,class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:publicText,class:"select-all")
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/badge/RunBadgeAction/index.properties
+++ b/src/main/resources/org/jenkinsci/plugins/badge/RunBadgeAction/index.properties
@@ -17,3 +17,6 @@ blurb=Jenkins exposes the status of the specific build as an image in a fixed UR
         <li><b>plastic</b> (the one used in version 1.5)\
       </ul> \
       You can choose the one you prefer by appending <tt>?style=plastic</tt> to the URL.
+blurb_text=Jenkins also exposes the current status of your build in plain text. \
+      You can use this in external scripts for easier interpretation of the current state of the build. \
+      Similar to the badge there are both <b>with view</b> and <b>without view</b> for <b>protected</b>, as well as <b>unprotected</b> variants.


### PR DESCRIPTION
Instead of doing the image, nice to have it just return text.
Thus the icon's description was chosen.
