### PR TITLE
[JENKINS-42656] Return HTTP 500 on missing job query parameter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/PublicBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/PublicBadgeAction.java
@@ -91,6 +91,10 @@ public class PublicBadgeAction implements UnprotectedRootAction {
      * Serves the badge image.
      */
     public HttpResponse doIcon(StaplerRequest req, StaplerResponse rsp, @QueryParameter String job, @QueryParameter String build, @QueryParameter String style) {
+        if (job == null) {
+            return HttpResponses.errorWithoutStack(400, "Missing query parameter: job");
+        }
+
         if(build != null) {
             Run run = getRun(job, build);
             return iconResolver.getImage(run.getIconColor(), style);
@@ -104,6 +108,10 @@ public class PublicBadgeAction implements UnprotectedRootAction {
      * Serves text.
      */
     public String doText(StaplerRequest req, StaplerResponse rsp, @QueryParameter String job, @QueryParameter String build) {
+        if (job == null) {
+            throw HttpResponses.errorWithoutStack(400, "Missing query parameter: job");
+        }
+
         if(build != null) {
             Run run = getRun(job, build);
             return run.getIconColor().getDescription();


### PR DESCRIPTION
Jira: https://issues.jenkins-ci.org/browse/JENKINS-42656 

With this PR, when entering https://<jenkins server>/buildStatus/icon you get a HTTP 500 with a message saying "Missing query parameter: job". Previously you would get presented with a nullpointer exception and a stack trace.