### PR TITLE
Fixed URL in <scm> section in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/git-plugin</url>
+    <url>http://github.com/jenkinsci/embeddable-build-status-plugin</url>
     <tag>HEAD</tag>
   </scm>
     <!-- Workflow plugin imports are used to test compatibility -->


### PR DESCRIPTION
Looks like it was not updated to proper version since the initial commit.
See https://issues.jenkins-ci.org/browse/WEBSITE-397