### PR TITLE
move docs to GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>embeddable-build-status</artifactId>
   <version>2.0.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin</url>
+  <url>https://github.com/jenkinsci/embeddable-build-status-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
update the `<url>` field so that plugin docs points to GitHub
see https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/#how-to-enable-github-documentation-for-your-plugin