### PR TITLE
Require Jenkins 2.332.4, build with Java 8, 11, or 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,7 @@
-buildPlugin()
+buildPlugin(failfast: false,
+    configurations: [
+        // [platform: 'linux',   jdk: '17', jenkins: '2.346.1'],
+        // [platform: 'linux',   jdk: '11'],
+        [platform: 'windows', jdk:  '8']
+    ]
+)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildPlugin(failfast: false,
     configurations: [
-        // [platform: 'linux',   jdk: '17', jenkins: '2.346.1'],
-        // [platform: 'linux',   jdk: '11'],
+        [platform: 'linux',   jdk: '17', jenkins: '2.346.1'],
+        [platform: 'linux',   jdk: '11'],
         [platform: 'windows', jdk:  '8']
     ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,13 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.50</version>
+    <version>4.41</version>
     <relativePath />
   </parent>
   <properties>
     <revision>2.0.5</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.1</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.332.4</jenkins.version>
   </properties>
 
   <name>Embeddable Build Status Plugin</name>
@@ -50,12 +49,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.49</version>
+      <version>1175.v4b_d517d6db_f0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.14</version>
+      <version>625.vd896b_f445a_f8</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtension.java
@@ -41,7 +41,11 @@ public class SpecialValueParameterResolverExtension implements ParameterResolver
                     } else if (customKey.equals("duration")) {
                         parameter = matcher.replaceFirst(run.getDurationString());
                     } else if (customKey.equals("description")) {
-                        parameter = matcher.replaceFirst(run.getDescription());
+                        String description = run.getDescription();
+                        if (description == null) {
+                            description = "";
+                        }
+                        parameter = matcher.replaceFirst(description);
                     } else if (customKey.equals("displayName")) {
                         parameter = matcher.replaceFirst(run.getDisplayName());
                     } else if (customKey.equals("startTime")) {


### PR DESCRIPTION
## Require Jenkins 2.332.4, build with Java 8, 11, or 17

Require Jenkins 2.332.4 or newer, since Jenkins 2.332.4 is the oldest LTS release with no open security advisory.

- Prepare to test with multiple Java versions
- Prevent NPE on null run description
- Require Jenkins 2.332.4 or newer
- Test Java 11 and Java 17 in CI

Also recommended by [developer documentation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
