### PR TITLE
[JENKINS-69019] Use expected version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <name>Embeddable Build Status Plugin</name>
   <artifactId>embeddable-build-status</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>${changelist}</version>
   <packaging>hpi</packaging>
   <url>https://github.com/jenkinsci/embeddable-build-status-plugin</url>
 


### PR DESCRIPTION
## [JENKINS-69019](https://issues.jenkins.io/browse/JENKINS-69019) Supercede nonsense version number

Fix incorrect version number `${revision}231.v678984136a_0b_` generated by prior release.

See https://github.com/jenkins-infra/update-center2/pull/618 for the update center pull request to suspend distribution of the nonsense version number.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
