### PR TITLE
Replace deprecated APIs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
@@ -52,7 +52,7 @@ class StatusImage implements HttpResponse {
     private final byte[] payload;
     private static final String PLGIN_NAME = "embeddable-build-status";
 
-    private static final Jenkins jInstance = Jenkins.getInstance();
+    private static final Jenkins jInstance = Jenkins.get();
     private static final PluginWrapper plugin = jInstance.pluginManager.getPlugin(PLGIN_NAME);
     private static final URL baseUrl = (plugin != null ? plugin.baseResourceURL : null);
 
@@ -87,7 +87,7 @@ class StatusImage implements HttpResponse {
     }
 
     StatusImage(String fileName) throws IOException {
-        URL rootUrl = new URL(jInstance != null ? jInstance.getRootUrl() : "");
+        URL rootUrl = new URL(jInstance.getRootUrl());
         etag = '"' + fileName + '"';
 
         URL image = new URL(rootUrl, fileName);

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/PublicBuildStatusAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/PublicBuildStatusAction.java
@@ -47,7 +47,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @Extension
 public class PublicBuildStatusAction implements UnprotectedRootAction {
     public final static Permission VIEW_STATUS = new Permission(Item.PERMISSIONS, "ViewStatus", Messages._ViewStatus_Permission(), Item.READ, PermissionScope.ITEM);
-    private static final Jenkins jInstance = Jenkins.getInstance();
+    private static final Jenkins jInstance = Jenkins.get();
     private IconRequestHandler iconRequestHandler;
     public PublicBuildStatusAction() throws IOException {
         iconRequestHandler = new IconRequestHandler();
@@ -125,7 +125,7 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
                     }
                 }
 
-                if (p == null && jInstance != null) {
+                if (p == null) {
                     p = jInstance.getItemByFullName(job, Job.class);
                 }
            } finally {

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/PublicBuildStatusAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/PublicBuildStatusAction.java
@@ -13,6 +13,7 @@ import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.security.Permission;
 import hudson.security.PermissionScope;
 import hudson.util.HttpResponses;
@@ -21,8 +22,6 @@ import java.io.IOException;
 
 import jenkins.model.Jenkins;
 
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -113,10 +112,9 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
     private static Job<?, ?> getProject(String job, Boolean throwErrorWhenNotFound) {
         Job<?, ?> p = null;
         if (job != null) {
-            // as the user might have ViewStatus permission only (e.g. as anonymous) we get get the project impersonate and check for permission after getting the project
-            SecurityContext orig = ACL.impersonate(ACL.SYSTEM);
+            // as the user might have ViewStatus permission only (e.g. as anonymous) we get the project impersonate and check for permission after getting the project
 
-            try {
+            try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
                 // first try to get Job via JobSelectorExtensionPoints
                 for (JobSelectorExtensionPoint jobSelector : ExtensionList.lookup(JobSelectorExtensionPoint.class)) {
                     p = jobSelector.select(job);
@@ -128,8 +126,6 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
                 if (p == null) {
                     p = jInstance.getItemByFullName(job, Job.class);
                 }
-           } finally {
-                SecurityContextHolder.setContext(orig);
             }
         }
 
@@ -150,8 +146,7 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
 
         if (project != null && build != null) {
             // as the user might have ViewStatus permission only (e.g. as anonymous) we get get the project impersonate and check for permission after getting the project
-            SecurityContext orig = ACL.impersonate(ACL.SYSTEM);
-            try {
+            try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
                 for (String token : build.split(",")) {
                     Run newRun = null;
                     // first: try to get Run via our InternalRunSelectorExtensionPoints
@@ -178,9 +173,7 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
                         break;
                     }
                 }
-            } finally {
-                SecurityContextHolder.setContext(orig);
-            }    
+            }
         }
         // check if user has permission to view the status
         if (run == null || !run.hasPermission(VIEW_STATUS)) {


### PR DESCRIPTION
Replaces deprecated APIs:

- `Jenkins.getInstance()` --> `Jenkins.get()` (+ no `null`-check needed)
- `ACL.impersonate()` --> `ACL.as2`

There's an [_`extends Plugin`_](https://github.com/jenkinsci/embeddable-build-status-plugin/blob/master/src/main/java/org/jenkinsci/plugins/badge/PluginImpl.java) left, but I don't know how to replace this in a compatible manner. 

-----------------------------------


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
