### PR TITLE
Read default font only once

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
@@ -246,4 +246,19 @@ class StatusImage implements HttpResponse {
         rsp.setHeader("Content-Length", length);
         rsp.getOutputStream().write(payload);
     }
+
+    /* Package protected getters for tests */
+    String getEtag() {
+        return etag;
+    }
+
+    /* Package protected getters for tests */
+    String getLength() {
+        return length;
+    }
+
+    /* Package protected getters for tests */
+    String getContentType() {
+        return contentType;
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -25,7 +25,11 @@ package org.jenkinsci.plugins.badge;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+
 import org.jvnet.hudson.test.JenkinsRule;
+
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
@@ -52,5 +56,161 @@ public class StatusImageTest {
         assertThat(statusImage.measureText(","), is(4));
         assertThat(statusImage.measureText("WWWWWWWWWW"), is(90)); // 110 in Verdana
         assertThat(statusImage.measureText("When in the course of human events it becomes necessary"), is(330)); // 338 in Verdana
+    }
+
+    private static final String PNG_CONTENT_TYPE = "image/png";
+    private static final String SVG_CONTENT_TYPE = "image/svg+xml;charset=utf-8";
+
+    @Test
+    public void testConstructorExamplePage() throws Exception {
+        String subject = "Custom Subject";
+        String status = "Any State";
+        String colorName = "darkturquoise";
+        String animatedColorName = null;
+        String style = null;
+        String link = null;
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        assertThat(statusImage.getEtag(), containsString(subject));
+        assertThat(statusImage.getEtag(), containsString(status));
+        assertThat(statusImage.getEtag(), containsString(colorName));
+        assertThat(statusImage.getEtag(), containsString("null"));
+        assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
+        assertThat(statusImage.getLength(), is("940"));
+    }
+
+    @Test
+    public void testConstructorFailingBuildPlasticStyle() throws Exception {
+        String subject = "build";
+        String status = "failing";
+        String colorName = "red";
+        String animatedColorName = null;
+        String style = "plastic";
+        String link = null;
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        assertThat(statusImage.getEtag(), containsString(subject));
+        assertThat(statusImage.getEtag(), containsString(status));
+        assertThat(statusImage.getEtag(), containsString(colorName));
+        assertThat(statusImage.getEtag(), containsString(style));
+        assertThat(statusImage.getEtag(), containsString("null"));
+        assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
+        assertThat(statusImage.getLength(), is("1003"));
+    }
+
+    @Test
+    public void testConstructorFailingBuildPlasticStyleNumericColor() throws Exception {
+        String subject = "build";
+        String status = "failing";
+        String colorName = "ff0000";
+        String animatedColorName = null;
+        String style = "plastic";
+        String link = null;
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        assertThat(statusImage.getEtag(), containsString(subject));
+        assertThat(statusImage.getEtag(), containsString(status));
+        assertThat(statusImage.getEtag(), containsString(colorName));
+        assertThat(statusImage.getEtag(), containsString(style));
+        assertThat(statusImage.getEtag(), containsString("null"));
+        assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
+        assertThat(statusImage.getLength(), is("1003"));
+    }
+
+    @Test
+    public void testConstructorPassingBuildPlasticStyle() throws Exception {
+        String subject = "build";
+        String status = "passing";
+        String colorName = "brightgreen";
+        String animatedColorName = null;
+        String style = "plastic";
+        String link = null;
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        assertThat(statusImage.getEtag(), containsString(subject));
+        assertThat(statusImage.getEtag(), containsString(status));
+        assertThat(statusImage.getEtag(), containsString(colorName));
+        assertThat(statusImage.getEtag(), containsString(style));
+        assertThat(statusImage.getEtag(), containsString("null"));
+        assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
+        assertThat(statusImage.getLength(), is("1003"));
+    }
+
+    @Test
+    public void testConstructorFailingBuildFlatSquareStyle() throws Exception {
+        String subject = "build";
+        String status = "failing";
+        String colorName = "red";
+        String animatedColorName = null;
+        String style = "flat-square";
+        String link = null;
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        assertThat(statusImage.getEtag(), containsString(subject));
+        assertThat(statusImage.getEtag(), containsString(status));
+        assertThat(statusImage.getEtag(), containsString(colorName));
+        assertThat(statusImage.getEtag(), containsString(style));
+        assertThat(statusImage.getEtag(), containsString("null"));
+        assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
+        assertThat(statusImage.getLength(), is("525"));
+    }
+
+    @Test
+    public void testConstructorPassingBuildFlatSquareStyle() throws Exception {
+        String subject = "build";
+        String status = "passing";
+        String colorName = "brightgreen";
+        String animatedColorName = null;
+        String style = "flat-square";
+        String link = null;
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        assertThat(statusImage.getEtag(), containsString(subject));
+        assertThat(statusImage.getEtag(), containsString(status));
+        assertThat(statusImage.getEtag(), containsString(colorName));
+        assertThat(statusImage.getEtag(), containsString(style));
+        assertThat(statusImage.getEtag(), containsString("null"));
+        assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
+        assertThat(statusImage.getLength(), is("525"));
+    }
+
+    @Test
+    public void testConstructor() throws Exception {
+        String subject = "build";
+        String status = "not run";
+        String colorName = "lightgrey";
+        String animatedColorName = null;
+        String style = null;
+        String link = null;
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        assertThat(statusImage.getEtag(), containsString(subject));
+        assertThat(statusImage.getEtag(), containsString(status));
+        assertThat(statusImage.getEtag(), containsString(colorName));
+        assertThat(statusImage.getEtag(), containsString("null"));
+        assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
+        assertThat(statusImage.getLength(), is("902"));
+    }
+
+    @Test
+    public void testConstructorPassingBuild32x32BallStyle() throws Exception {
+        String fileName = "/jenkins/static/3fcf04bd/images/32x32/blue.png";
+        StatusImage statusImage = new StatusImage(fileName);
+        assertThat(statusImage.getEtag(), containsString(fileName));
+        // assertThat(statusImage.getContentType(), is(PNG_CONTENT_TYPE));
+        assertThat(statusImage.getLength(), is("1656"));
+    }
+
+    @Test
+    public void testConstructorPassingBuild16x16BallStyle() throws Exception {
+        String fileName = "/jenkins/static/3fcf04bd/images/16x16/blue.png";
+        StatusImage statusImage = new StatusImage(fileName);
+        assertThat(statusImage.getEtag(), containsString(fileName));
+        // assertThat(statusImage.getContentType(), is(PNG_CONTENT_TYPE));
+        assertThat(statusImage.getLength(), is("656"));
+    }
+
+    // @Test
+    public void testGenerateResponse() throws Exception {
+        System.out.println("generateResponse");
+        StaplerRequest req = null;
+        StaplerResponse rsp = null;
+        Object node = null;
+        StatusImage instance = new StatusImage();
+        instance.generateResponse(req, rsp, node);
+        // TODO review the generated test code and remove the default call to fail.
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -202,15 +202,4 @@ public class StatusImageTest {
         // assertThat(statusImage.getContentType(), is(PNG_CONTENT_TYPE));
         assertThat(statusImage.getLength(), is("656"));
     }
-
-    // @Test
-    public void testGenerateResponse() throws Exception {
-        System.out.println("generateResponse");
-        StaplerRequest req = null;
-        StaplerResponse rsp = null;
-        Object node = null;
-        StatusImage instance = new StatusImage();
-        instance.generateResponse(req, rsp, node);
-        // TODO review the generated test code and remove the default call to fail.
-    }
 }


### PR DESCRIPTION
## Read the default font only once

- Add more StatusImage tests to assure compatibility
- Read default font only once for faster performance

Read default font only once for faster performance

JMeter test runs indicate that a single initialization of the default font reduces the HTTP response time by more than 50% and increases the throughout by more than 2x.

JMeter test runs were not exhaustive (30000 samples using a Linux controller running in a Docker container with the JMeter test from my Windows desktop), but they showed similar or better results on multiple runs.

Average response time before the change was 15ms. Average response time after the change ranged from 3-8 ms.

Median response time before the change was 10 ms. Median response time after the change was 2-3 ms with one 7ms outlier.

Throughput before the change was less than 200 requests per second. Throughput after the change was over 450 requests per second.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
