### PR TITLE
Allow range of width values in tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -55,7 +55,6 @@ public class StatusImageTest {
         assertThat(statusImage.measureText("When in the course of human events it becomes necessary"), is(330)); // 338 in Verdana
     }
 
-    private static final String PNG_CONTENT_TYPE = "image/png";
     private static final String SVG_CONTENT_TYPE = "image/svg+xml;charset=utf-8";
 
     @Test
@@ -181,6 +180,8 @@ public class StatusImageTest {
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
         assertThat(statusImage.getLength(), is("902"));
     }
+
+    // private static final String PNG_CONTENT_TYPE = "image/png";
 
     @Test
     public void testConstructorPassingBuild32x32BallStyle() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -30,6 +30,8 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 
 public class StatusImageTest {
 
@@ -71,7 +73,7 @@ public class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(statusImage.getLength(), is("940"));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(920), lessThan(960)));
     }
 
     @Test
@@ -89,7 +91,7 @@ public class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(statusImage.getLength(), is("1003"));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
     }
 
     @Test
@@ -107,7 +109,7 @@ public class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(statusImage.getLength(), is("1003"));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
     }
 
     @Test
@@ -125,7 +127,7 @@ public class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(statusImage.getLength(), is("1003"));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
     }
 
     @Test
@@ -143,7 +145,7 @@ public class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(statusImage.getLength(), is("525"));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(510), lessThan(540)));
     }
 
     @Test
@@ -161,7 +163,7 @@ public class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(statusImage.getLength(), is("525"));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(510), lessThan(540)));
     }
 
     @Test
@@ -178,7 +180,7 @@ public class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(statusImage.getLength(), is("902"));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(875), lessThan(925)));
     }
 
     // private static final String PNG_CONTENT_TYPE = "image/png";

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -187,7 +187,7 @@ public class StatusImageTest {
 
     @Test
     public void testConstructorPassingBuild32x32BallStyle() throws Exception {
-        String fileName = "/jenkins/static/3fcf04bd/images/32x32/blue.png";
+        String fileName = "images/32x32/blue.png";
         StatusImage statusImage = new StatusImage(fileName);
         assertThat(statusImage.getEtag(), containsString(fileName));
         // assertThat(statusImage.getContentType(), is(PNG_CONTENT_TYPE));
@@ -196,7 +196,7 @@ public class StatusImageTest {
 
     @Test
     public void testConstructorPassingBuild16x16BallStyle() throws Exception {
-        String fileName = "/jenkins/static/3fcf04bd/images/16x16/blue.png";
+        String fileName = "images/16x16/blue.png";
         StatusImage statusImage = new StatusImage(fileName);
         assertThat(statusImage.getEtag(), containsString(fileName));
         // assertThat(statusImage.getContentType(), is(PNG_CONTENT_TYPE));

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -28,9 +28,6 @@ import org.junit.Test;
 
 import org.jvnet.hudson.test.JenkinsRule;
 
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
-
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 


### PR DESCRIPTION
## Allow a range of width values in status image tests

Windows computers in my CI cluster report slightly different values for text widths than the Windows computers on ci.jenkins.io.

Linux and other computers report same values.

Specific values are not as important as keeping the width value within a reasonable range.

- Allow range of width values in tests

Other changes included in the pull request include:

- Remove unused imports from test code
- Move PNG content type test code together
- Remove variable portion of image path from test

None of those other improvements are substantial enough to justify a separate pull request.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
