### PR TITLE
Replace tango icons with ionicons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.332.4</jenkins.version>
+    <jenkins.version>2.346.1</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
   </properties>
@@ -56,13 +56,18 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>ionicons-api</artifactId>
+      <version>28.va_f3a_84439e5f</version>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
-            <artifactId>bom-2.332.x</artifactId>
+            <artifactId>bom-2.346.x</artifactId>
             <version>1607.va_c1576527071</version>
             <scope>import</scope>
             <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.346.1</jenkins.version>
+    <jenkins.version>2.346.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
   </properties>

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/JobBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/JobBadgeAction.java
@@ -36,7 +36,7 @@ public class JobBadgeAction implements Action, IconSpec {
 
     @Override
     public String getIconClassName() {
-        return "icon-shield";
+        return "symbol-shield-outline plugin-ionicons-api";
     }
 
     public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/RunBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/RunBadgeAction.java
@@ -32,7 +32,7 @@ public class RunBadgeAction implements Action, IconSpec {
 
     @Override
     public String getIconClassName() {
-        return "icon-shield";
+        return "symbol-shield-outline plugin-ionicons-api";
     }
 
     public String getDisplayName() {


### PR DESCRIPTION
The change proposed replaces the left-over tango icon reference with an ionicon one.

Before:
![Screenshot 2022-10-01 at 20 17 13](https://user-images.githubusercontent.com/13383509/193422821-c3a75993-c5f4-462c-9481-acfcdd3f331b.png)

After:
![Screenshot 2022-10-01 at 20 16 52](https://user-images.githubusercontent.com/13383509/193422808-524a2681-7771-4423-b904-f1a6a87d31b7.png)