### PR TITLE
chore(Jenkinsfile): try the Artifact Caching Proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
 buildPlugin(failfast: false,
+    // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
+    // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
+    artifactCachingProxyEnabled: true,
     configurations: [
         [platform: 'linux',   jdk: '17', jenkins: '2.346.1'],
         [platform: 'linux',   jdk: '11'],


### PR DESCRIPTION
This PR activates the use of an Artifact Caching Proxy caching the requests done to repo.jenkins-ci.org sponsored by JFrog, in order to reduce our bandwidth consumption.
This is done by setting the new `artifactCachingProxyEnabled` parameter [recently added](https://github.com/jenkins-infra/pipeline-library/pull/502) to the shared pipeline library `buildPlugin` function.

Apart from an additional build log entry with the proxy provider configured for Maven depending on the agent location, there shouldn't be any change for any maintainer of this plugin, if there is any problem please describe it [in the related help desk issue](https://github.com/jenkins-infra/helpdesk/issues/2752).

This plugin has been chosen to check in situ this functionality (for now proposed as opt-in), [among some others](https://github.com/jenkins-infra/helpdesk/issues/2752#issuecomment-1287013172).

There will be another PR to remove these changes as soon as the functionality would have been approved and switched to opt-out.

cc @MarkEWaite

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
