### PR TITLE
Exclude mockito from packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>4.8.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Exclude mockito from hpi packaging

The mockito library is only used in tests so it should be scoped to tests.

Prevent unnecessary inclusion of mockito and its dependencies in the final hpi file.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
