### PR TITLE
Improve automated test coverage #114 - Add test for classes in default package

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/badge/JobBadgeActionFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/JobBadgeActionFactoryTest.java
@@ -1,0 +1,38 @@
+package org.jenkinsci.plugins.badge;
+
+import hudson.model.Action;
+import hudson.model.Job;
+import org.hamcrest.core.Is;
+import org.jenkinsci.plugins.badge.actions.JobBadgeAction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JobBadgeActionFactoryTest {
+
+    private JobBadgeActionFactory factory;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        factory = new JobBadgeActionFactory();
+    }
+
+    @Test
+    void shouldCreateJobBadgeAction() {
+        Collection<? extends Action> action = factory.createFor(Mockito.mock(Job.class));
+        assertThat(action.size(), is(1));
+        assertThat(action.stream().findFirst().get(), instanceOf(JobBadgeAction.class));
+    }
+
+    @Test
+    void shouldBeForJobType() {
+        assertThat(factory.type(), is(Job.class));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/badge/ParameterResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ParameterResolverTest.java
@@ -1,0 +1,22 @@
+package org.jenkinsci.plugins.badge;
+
+import hudson.model.Actionable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ParameterResolverTest {
+    @ParameterizedTest
+    @CsvSource({
+            "Build ${params.BUILD_BRANCH},Build params.BUILD_BRANCH",
+            "Build ${params.BUILD_BRANCH|master},Build params.BUILD_BRANCH|master",
+            "Build ${params.BUILD_BRANCH|master} (${displayName}),Build params.BUILD_BRANCH|master (displayName)"
+    })
+    void shouldResolveSubjectWithVariables(String queryParameter, String expectedParameter) {
+        String resolvedParameter = new ParameterResolver().resolve(Mockito.mock(Actionable.class), queryParameter);
+        assertThat(resolvedParameter, is(expectedParameter));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/badge/RunBadgeActionFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/RunBadgeActionFactoryTest.java
@@ -1,0 +1,39 @@
+package org.jenkinsci.plugins.badge;
+
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.Run;
+import org.jenkinsci.plugins.badge.actions.JobBadgeAction;
+import org.jenkinsci.plugins.badge.actions.RunBadgeAction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RunBadgeActionFactoryTest {
+
+    private RunBadgeActionFactory factory;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        factory = new RunBadgeActionFactory();
+    }
+
+    @Test
+    void shouldCreateJobBadgeAction() {
+        Collection<? extends Action> action = factory.createFor(Mockito.mock(Run.class));
+        assertThat(action.size(), is(1));
+        assertThat(action.stream().findFirst().get(), instanceOf(RunBadgeAction.class));
+    }
+
+    @Test
+    void shouldBeForJobType() {
+        assertThat(factory.type(), is(Run.class));
+    }
+}


### PR DESCRIPTION
Adds tests for the following classes in the default package.
* JobBadgeActionFactory
* RunBadgeActionFactory
* ParameterResolver - Added test for the example given in README. Would be great, if you can help add more use cases here.

Aims to address the https://github.com/jenkinsci/embeddable-build-status-plugin/issues/114 in smaller steps.