### PR TITLE
Prevent loop when parameter value contains parameter name

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtension.java
@@ -11,14 +11,13 @@ import hudson.model.Actionable;
 import hudson.model.Run;
 import hudson.model.Job;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Objects;
 
 import org.jenkinsci.plugins.badge.extensionpoints.ParameterResolverExtensionPoint;
 
 @Extension
-public class SpecialValueParameterResolverExtension implements ParameterResolverExtensionPoint {
-    private static Pattern custom = Pattern.compile("(buildId|buildNumber|duration|description|displayName|startTime)");
+public class SpecialValueParameterResolverExtension implements ParameterResolverExtensionPoint {    
+    
     public String resolve(Actionable actionable, String parameter) {
         if (parameter != null) {
             if (actionable instanceof Run<?, ?>) {
@@ -31,31 +30,14 @@ public class SpecialValueParameterResolverExtension implements ParameterResolver
                     ${displayName}
                     ${startTime}
                 */
-                Matcher matcher = custom.matcher(parameter);
-                while (matcher.find()) {
-                    String customKey = matcher.group(1);
-                    if (customKey.equals("buildId")) {
-                        parameter = matcher.replaceFirst(run.getId());
-                    } else if (customKey.equals("buildNumber")) {
-                        parameter = matcher.replaceFirst(Integer.toString(run.getNumber()));
-                    } else if (customKey.equals("duration")) {
-                        parameter = matcher.replaceFirst(run.getDurationString());
-                    } else if (customKey.equals("description")) {
-                        String description = run.getDescription();
-                        if (description == null) {
-                            description = "";
-                        }
-                        parameter = matcher.replaceFirst(description);
-                    } else if (customKey.equals("displayName")) {
-                        parameter = matcher.replaceFirst(run.getDisplayName());
-                    } else if (customKey.equals("startTime")) {
-                        parameter = matcher.replaceFirst(run.getTimestampString());
-                    } else {
-                        // this actually should NOT happen
-                        parameter = matcher.replaceFirst(customKey);
-                    }
-                    matcher = custom.matcher(parameter);
-                }
+                
+                parameter = parameter.replace("buildId", run.getId())
+                         .replace("buildNumber", Integer.toString(run.getNumber()))
+                         .replace("duration", run.getDurationString())
+                         .replace("description", Objects.toString(run.getDescription(), ""))
+                         .replace("displayName", run.getDisplayName())
+                         .replace("startTime", run.getTimestampString());
+                         
             } else if (actionable instanceof Job<?, ?>) {
                 parameter = resolve(((Job<?, ?>)actionable).getLastBuild(), parameter);
             }

--- a/src/test/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtensionTest.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.badge.extensions;
 
 import hudson.model.Job;
 import hudson.model.Run;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -61,5 +60,10 @@ class SpecialValueParameterResolverExtensionTest {
     void shouldResolveDescription() {       
         String actualParameter = extension.resolve(mockRun, "description");
         assertThat(actualParameter, is("run description"));
+    }
+    @Test
+    void testMultipleParameters() {
+        String actualParameter = extension.resolve(mockRun, "buildId buildNumber duration startTime displayName description");
+        assertThat(actualParameter, is("1234 1234 23:35 23:35 display name run description"));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtensionTest.java
@@ -19,46 +19,46 @@ class SpecialValueParameterResolverExtensionTest {
 
     @BeforeEach
     void setUp() {
-
         extension = new SpecialValueParameterResolverExtension();
         mockProject = Mockito.mock(Job.class);
+        
         mockRun = Mockito.mock(Run.class);
+        
+        when(mockRun.getId()).thenReturn("1234");
+        when(mockRun.getNumber()).thenReturn(1234);
+        when(mockRun.getDurationString()).thenReturn("23:35");
+        when(mockRun.getTimestampString()).thenReturn("23:35");
+        when(mockRun.getDisplayName()).thenReturn("display name");
+        when(mockRun.getDescription()).thenReturn("run description");        
     }
-//    (buildId|buildNumber|duration|description|displayName|startTime)
 
     @Test
-    void shouldResolveBuildId() {
-        when(mockRun.getId()).thenReturn("1234");
+    void shouldResolveBuildId() {        
         String actualParameter = extension.resolve(mockRun, "buildId");
         assertThat(actualParameter, is("1234"));
     }
     @Test
-    void shouldResolveBuildNumber() {
-        when(mockRun.getNumber()).thenReturn(1234);
+    void shouldResolveBuildNumber() {        
         String actualParameter = extension.resolve(mockRun, "buildNumber");
         assertThat(actualParameter, is("1234"));
     }
     @Test
-    void shouldResolveDuration() {
-        when(mockRun.getDurationString()).thenReturn("23:35");
+    void shouldResolveDuration() {        
         String actualParameter = extension.resolve(mockRun, "duration");
         assertThat(actualParameter, is("23:35"));
     }
     @Test
     void shouldResolveStartTime() {
-        when(mockRun.getTimestampString()).thenReturn("23:35");
         String actualParameter = extension.resolve(mockRun, "startTime");
         assertThat(actualParameter, is("23:35"));
     }
     @Test
-    void shouldResolveDisplayName() {
-        when(mockRun.getDisplayName()).thenReturn("display name");
+    void shouldResolveDisplayName() {        
         String actualParameter = extension.resolve(mockRun, "displayName");
         assertThat(actualParameter, is("display name"));
     }
-    @Ignore("Runs into an infinite loop. Needs debugging.")
-    void shouldResolveDescription() {
-        when(mockRun.getDescription()).thenReturn("run description");
+    @Test
+    void shouldResolveDescription() {       
         String actualParameter = extension.resolve(mockRun, "description");
         assertThat(actualParameter, is("run description"));
     }


### PR DESCRIPTION
Test `shouldResolveDescription` in `SpecialValueParameterResolverExtensionTest.java` had an ignore stating "Runs into an infinite loop. Needs debugging.":

```java
@Ignore("Runs into an infinite loop. Needs debugging.")
void shouldResolveDescription() {
    when(mockRun.getDescription()).thenReturn("run description");
        String actualParameter = extension.resolve(mockRun, "description");
        assertThat(actualParameter, is("run description"));
    }
```

This is because the `resolve` method replaces "description" with "run description" and then checks if "run description" has the string "description" in it, and if so, replaces "description" with "run descriptions", and so on.

It turns out, a loop was not needed (and indeed, the regex that was used to control the loop).

Also, from a glance at the code and tests, it seems the intent that exactly one parameter would be passed in and one parameter passed out, however, the way the code was written, this is not be the case. I've added an additional test case that demonstrates this:

```java
@Test
void testMultipleParameters() {
    String actualParameter = extension.resolve(mockRun, "buildId buildNumber duration startTime displayName description");
    assertThat(actualParameter, is("1234 1234 23:35 23:35 display name run description"));
}
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
