### PR TITLE
Add tests for ball logic in image resolver page 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "java.configuration.updateBuildConfiguration": "automatic"
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.debug.settings.onBuildFailureProceed": true
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.50</version>
+    <version>4.51</version>
     <relativePath />
   </parent>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,10 @@
       <artifactId>ionicons-api</artifactId>
     </dependency>
     <dependency>
-     <groupId>org.mockito</groupId>
-       <artifactId>mockito-core</artifactId>
-       <scope>test</scope>
-</dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>```
   </dependencies>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-    </dependency>```
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,14 @@
     </license>
   </licenses>
 
+  <developers>
+    <developer>
+      <id>markewaite</id>
+      <name>Mark Waite</name>
+      <email>mark.earl.waite@gmail.com</email>
+    </developer>
+  </developers>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,12 @@
       <artifactId>ionicons-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
+    <groupId>org.mockito</groupId>
+    <artifactId>mockito-inline</artifactId>
+    <version>2.13.0</version>
+    
+    <scope>test</scope>
+</dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -8,7 +8,10 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import org.mockito.Mockito;
+import org.mockito.Spy;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class ImageResolverTest {
     ImageResolver ImageTester;
@@ -21,8 +24,18 @@ public class ImageResolverTest {
         String status = "passing";
         String subject = "build";
         String colorName=null;
-        ImageTester.getImage(BallColor.BLUE,style,status,subject, colorName, null, null);
+        String fileName=  BallColor.getImageOf("32x32");
+        //StatusImage statusImage = new StatusImage(fileName);
+        BallColor.values();
+        BallColor ball = new BallColor();
+        BallColor ball = mock(BallColor.class);
+        ImageTester.getImage(BallColor.ABORTED_ANIME,style,status,subject, colorName, null, null);
 
+    }
+
+    @Test
+    void testName() {
+        
     }
 
 

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -1,7 +1,8 @@
 package org.jenkinsci.plugins.badge;
 
 import hudson.model.BallColor;
-
+import hudson.model.Messages;
+import hudson.util.ColorPalette;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,12 +25,12 @@ public class ImageResolverTest {
         String status = "passing";
         String subject = "build";
         String colorName=null;
-        String fileName=  BallColor.getImageOf("32x32");
         //StatusImage statusImage = new StatusImage(fileName);
-        BallColor.values();
-        BallColor ball = new BallColor();
+       
         BallColor ball = mock(BallColor.class);
-        ImageTester.getImage(BallColor.ABORTED_ANIME,style,status,subject, colorName, null, null);
+        Mockito.when(ball.getImageOf("32x32")).thenReturn("hello");
+        
+
 
     }
 

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -1,34 +1,25 @@
 package org.jenkinsci.plugins.badge;
 
-
-
 import org.junit.ClassRule;
 import hudson.model.BallColor;
 
 import org.junit.Test;
 
-
 import org.jvnet.hudson.test.JenkinsRule;
 
 import org.mockito.Mockito;
-import org.mockito.Spy;
-
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.IOException;
 
 public class ImageResolverTest {
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
     @Test
-    public void TestGetDefault32x32Ball() throws Exception {
+    public void testGetDefault32x32Ball() throws Exception {
         ImageResolver ImageTester = new ImageResolver();
         String style="ball-null"; // should give default due to url being null
         String status = null;
@@ -46,7 +37,7 @@ public class ImageResolverTest {
      
     }
     @Test
-    public void TestGetNonDefaultBall() throws Exception {
+    public void testGetNonDefaultBall() throws Exception {
         ImageResolver ImageTester = new ImageResolver();
         String style="ball-16x16"; // should give url
         String status = null;
@@ -55,7 +46,7 @@ public class ImageResolverTest {
         String fileName = "images/16x16/red.png";
         BallColor ball = mock(BallColor.class);
         //default
-        Mockito.when(ball.getImageOf("null")).thenReturn(null);
+        Mockito.when(ball.getImageOf("null")).thenReturn(null); 
         Mockito.when(ball.getImageOf("16x16")).thenReturn(fileName);
         Mockito.when(ball.noAnime()).thenCallRealMethod();
         StatusImage TestImage = ImageTester.getImage(ball, style,subject,status, colorName, null, null);

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -2,22 +2,23 @@ package org.jenkinsci.plugins.badge;
 
 import org.junit.ClassRule;
 import hudson.model.BallColor;
+
 import java.io.IOException;
 import java.util.Random;
 
 import org.junit.Test;
 
+
 import org.jvnet.hudson.test.JenkinsRule;
 
-import org.mockito.Mockito;
-<<<<<<< HEAD
-=======
+
+
 
 import static org.hamcrest.MatcherAssert.assertThat;
->>>>>>> 9483900f4867983ecdda36804c4700a97ff89f0a
-import static org.mockito.Mockito.mock;
+
 
 import static org.hamcrest.CoreMatchers.*;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -25,7 +26,37 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 
+class ImageResolverBallDummy extends ImageResolver{
+    @Override
+    public StatusImage getImage(BallColor color, String style, String subject, String status, String colorName,
+            String animatedOverlayColor, String link) {
+        // TODO Auto-generated method stub
+
+        if (style != null) {
+            String[] styleParts = style.split("-");
+            if (styleParts.length == 2 && styleParts[0].equals("ball")) {
+                String url =  "images/" + styleParts[1] + '/' + color.getImage();
+                if (url.contains("null")) {
+                    url =   "images/" + "32x32" + '/' + color.getImage();
+                }
+
+                if (url != null) {
+                    try {
+                        return new StatusImage(url);
+                    } catch (IOException ioe) {
+                        return new StatusImage();
+                    }
+                }
+            }
+        }
+        style = null;
+        return super.getImage(color, style, subject, status, colorName, animatedOverlayColor, link);
+    }
+
+}
 public class ImageResolverTest {
+
+ 
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
@@ -48,56 +79,45 @@ public class ImageResolverTest {
     @After
     public void tearDown() throws Exception {
     }
+  
 
-    // @Test
+    @Test
     public void TestGetDefault32x32Ball() throws Exception {
-        ImageResolver ImageTester = new ImageResolver();
+        ImageResolverBallDummy ImageTester = new ImageResolverBallDummy();
         String style = "ball-null"; // should give default due to url being null
         String status = null;
         String subject = null;
         String colorName = null;
         String fileName = "images/32x32/blue.png";
-        BallColor ball = mock(BallColor.class);
-        //default
-        Mockito.when(ball.getImageOf("null")).thenReturn(null);
-        Mockito.when(ball.getImageOf("32x32")).thenReturn(fileName);
-        Mockito.when(ball.noAnime()).thenCallRealMethod();
+        BallColor ball=BallColor.BLUE;
         StatusImage TestImage = ImageTester.getImage(ball, style, subject, status, colorName, null, null);
         assertThat(TestImage.getEtag(), containsString(fileName));
 
     }
 
-    // @Test
+    @Test
     public void TestGetNonDefaultBall() throws Exception {
-        ImageResolver ImageTester = new ImageResolver();
+        ImageResolverBallDummy ImageTester = new ImageResolverBallDummy();
         String style = "ball-16x16"; // should give url
         String status = null;
         String subject = null;
         String colorName = null;
         String fileName = "images/16x16/red.png";
-        BallColor ball = mock(BallColor.class);
-        //default
-        Mockito.when(ball.getImageOf("null")).thenReturn(null); 
-        Mockito.when(ball.getImageOf("16x16")).thenReturn(fileName);
-        Mockito.when(ball.noAnime()).thenCallRealMethod();
+        BallColor ball=BallColor.RED;
         StatusImage TestImage = ImageTester.getImage(ball, style, subject, status, colorName, null, null);
         assertThat(TestImage.getEtag(), containsString(fileName));
 
     }
 
-    // @Test
+    @Test
     public void testShouldReturnEmpty() throws Exception {
-        ImageResolver ImageTester = new ImageResolver();
+        ImageResolverBallDummy ImageTester = new ImageResolverBallDummy();
         String style = "ball-42x45"; // should throw exception
         String status = null;
         String subject = null;
         String colorName = null;
-        String fileName = "DoesNotExist";;
-        BallColor ball = mock(BallColor.class);
-        //default
-        Mockito.when(ball.getImageOf("null")).thenReturn(null);
-        Mockito.when(ball.getImageOf("42x45")).thenReturn(fileName);
-        Mockito.when(ball.noAnime()).thenCallRealMethod();
+        String fileName = "DoesNotExist";
+        BallColor ball=BallColor.BLUE;
         StatusImage TestImage = ImageTester.getImage(ball, style, subject, status, colorName, null, null);
         assertThat(TestImage.getEtag(), containsString("empty"));
 
@@ -116,6 +136,7 @@ public class ImageResolverTest {
     private String getStatus() {
         return "status-is-" + testName.getMethodName();
     }
+
 
     private BallColor[] jobStatusColors = {
         BallColor.ABORTED_ANIME,
@@ -210,4 +231,6 @@ public class ImageResolverTest {
         assertThat(image.getContentType(), is("image/svg+xml;charset=utf-8"));
         assertThat(image.measureText("W"), is(9));
     }
+   
 }
+

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -30,7 +30,6 @@ class ImageResolverBallDummy extends ImageResolver{
     @Override
     public StatusImage getImage(BallColor color, String style, String subject, String status, String colorName,
             String animatedOverlayColor, String link) {
-        // TODO Auto-generated method stub
 
         if (style != null) {
             String[] styleParts = style.split("-");
@@ -63,23 +62,6 @@ public class ImageResolverTest {
 
     @Rule
     public TestName testName = new TestName();
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
-  
 
     @Test
     public void TestGetDefault32x32Ball() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.plugins.badge;
+
+import hudson.model.BallColor;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ImageResolverTest {
+    ImageResolver ImageTester;
+    
+    @Test
+    void BallShouldBeDefault(){
+        ImageTester = new ImageResolver();
+        String s = "Hello";
+        String style="ball-32x32";
+        String status = "passing";
+        String subject = "build";
+       
+        ImageTester.getImage(BallColor.BLUE,style,status,subject, null, null, null);
+
+    }
+
+
+}

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -1,12 +1,14 @@
 package org.jenkinsci.plugins.badge;
 
+
+
+import org.junit.ClassRule;
 import hudson.model.BallColor;
-import hudson.model.Messages;
-import hudson.util.ColorPalette;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import org.junit.jupiter.api.Test;
+
+import org.junit.Test;
+
+
+import org.jvnet.hudson.test.JenkinsRule;
 
 import org.mockito.Mockito;
 import org.mockito.Spy;
@@ -14,30 +16,35 @@ import org.mockito.Spy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+import java.io.IOException;
+
 public class ImageResolverTest {
-    ImageResolver ImageTester;
-    
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
+
     @Test
-    void BallShouldBeDefault(){
-        ImageTester = new ImageResolver();
-        String s = "Hello";
-        String style="ball-32x32";
-        String status = "passing";
-        String subject = "build";
+    public void TestGetDefault32x32Ball() throws Exception {
+        ImageResolver ImageTester = new ImageResolver();
+        String style="ball-Error"; // should give default due to url being null
+        String status = null;
+        String subject = null;
         String colorName=null;
-        //StatusImage statusImage = new StatusImage(fileName);
-       
+        String fileName = "images/32x32/blue.png";
         BallColor ball = mock(BallColor.class);
-        Mockito.when(ball.getImageOf("32x32")).thenReturn("hello");
-        
+        //default
+        Mockito.when(ball.getImageOf("Error")).thenReturn(null);
+        Mockito.when(ball.getImageOf("32x32")).thenReturn(fileName);
+        Mockito.when(ball.noAnime()).thenCallRealMethod();
+        StatusImage TestImage = ImageTester.getImage(ball, style,subject,status, colorName, null, null);
+        assertThat(TestImage.getEtag(), containsString(fileName));
 
-
+     
     }
-
-    @Test
-    void testName() {
-        
-    }
-
-
 }
+
+

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -8,14 +8,9 @@ import java.util.Random;
 
 import org.junit.Test;
 
-
 import org.jvnet.hudson.test.JenkinsRule;
 
-
-
-
 import static org.hamcrest.MatcherAssert.assertThat;
-
 
 import static org.hamcrest.CoreMatchers.*;
 
@@ -54,8 +49,6 @@ class ImageResolverBallDummy extends ImageResolver{
 
 }
 public class ImageResolverTest {
-
- 
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
@@ -118,7 +111,6 @@ public class ImageResolverTest {
     private String getStatus() {
         return "status-is-" + testName.getMethodName();
     }
-
 
     private BallColor[] jobStatusColors = {
         BallColor.ABORTED_ANIME,
@@ -213,6 +205,5 @@ public class ImageResolverTest {
         assertThat(image.getContentType(), is("image/svg+xml;charset=utf-8"));
         assertThat(image.measureText("W"), is(9));
     }
-   
-}
 
+}

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -30,14 +30,14 @@ public class ImageResolverTest {
     @Test
     public void TestGetDefault32x32Ball() throws Exception {
         ImageResolver ImageTester = new ImageResolver();
-        String style="ball-Error"; // should give default due to url being null
+        String style="ball-null"; // should give default due to url being null
         String status = null;
         String subject = null;
         String colorName=null;
         String fileName = "images/32x32/blue.png";
         BallColor ball = mock(BallColor.class);
         //default
-        Mockito.when(ball.getImageOf("Error")).thenReturn(null);
+        Mockito.when(ball.getImageOf("null")).thenReturn(null);
         Mockito.when(ball.getImageOf("32x32")).thenReturn(fileName);
         Mockito.when(ball.noAnime()).thenCallRealMethod();
         StatusImage TestImage = ImageTester.getImage(ball, style,subject,status, colorName, null, null);
@@ -45,6 +45,43 @@ public class ImageResolverTest {
 
      
     }
+    @Test
+    public void TestGetNonDefaultBall() throws Exception {
+        ImageResolver ImageTester = new ImageResolver();
+        String style="ball-16x16"; // should give url
+        String status = null;
+        String subject = null;
+        String colorName=null;
+        String fileName = "images/16x16/red.png";
+        BallColor ball = mock(BallColor.class);
+        //default
+        Mockito.when(ball.getImageOf("null")).thenReturn(null);
+        Mockito.when(ball.getImageOf("16x16")).thenReturn(fileName);
+        Mockito.when(ball.noAnime()).thenCallRealMethod();
+        StatusImage TestImage = ImageTester.getImage(ball, style,subject,status, colorName, null, null);
+        assertThat(TestImage.getEtag(), containsString(fileName));
+
+     
+    }
+    @Test
+    public void testShouldReturnEmpty() throws Exception {
+        ImageResolver ImageTester = new ImageResolver();
+        String style="ball-42x45"; // should throw exception
+        String status = null;
+        String subject = null;
+        String colorName=null;
+        String fileName = "DoesNotExist";;
+        BallColor ball = mock(BallColor.class);
+        //default
+        Mockito.when(ball.getImageOf("null")).thenReturn(null);
+        Mockito.when(ball.getImageOf("42x45")).thenReturn(fileName);
+        Mockito.when(ball.noAnime()).thenCallRealMethod();
+        StatusImage TestImage = ImageTester.getImage(ball, style,subject,status, colorName, null, null);
+        assertThat(TestImage.getEtag(), containsString("empty"));
+
+     
+    }
 }
+
 
 

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -20,8 +20,8 @@ public class ImageResolverTest {
         String style="ball-32x32";
         String status = "passing";
         String subject = "build";
-       
-        ImageTester.getImage(BallColor.BLUE,style,status,subject, null, null, null);
+        String colorName=null;
+        ImageTester.getImage(BallColor.BLUE,style,status,subject, colorName, null, null);
 
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This merge has 3 unit tests covering Ball Logic, First Test sees if the default 32x32 image logic is correct. The second is just a regular ball, and 3rd is an empty test case. I also Updated Mockito so it works with Final classes.  Still need to cover non-ball image requests but will handle that at a later time.  #114 
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
-  [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
