### PR TITLE
[JENKINS-70602] Fix overwriting system fonts

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
@@ -23,12 +23,12 @@ l.layout {
 </script>
 <style>
     INPUT {
-        font-family: Console, "Courier New", Courier, monospace;
         border: none;
         font-size: -2;
     }
     INPUT.select-all {
         width:100%;
+        font-family: Console, "Courier New", Courier, monospace;
     }
     IMG#badge {
         margin-left:2em;

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
@@ -23,12 +23,12 @@ l.layout {
 </script>
 <style>
     INPUT {
-        font-family: Console, "Courier New", Courier, monospace;
         border: none;
         font-size: -2;
     }
     INPUT.select-all {
         width:100%;
+        font-family: Console, "Courier New", Courier, monospace;
     }
     IMG#badge {
         margin-left:2em;


### PR DESCRIPTION
This PR addresses [JENKINS-70602](https://issues.jenkins.io/browse/JENKINS-70602) by shifting the font changes down the hierarchy to the object it actually modifies and ensures Jenkins' fonts remain untouched while custom fonts on the embeddable build status badge page use the console-like font still:
![Screenshot 2023-02-12 at 09 03 24](https://user-images.githubusercontent.com/13383509/218299800-8b91c4bf-6b1d-4ea9-8eb6-6d6422c16b58.png)
![Screenshot 2023-02-12 at 09 04 53](https://user-images.githubusercontent.com/13383509/218299846-6a8c37c5-e12a-42db-9351-260075e92b27.png)

---

This resolves the issue for now, but I would consider this a short-term fix only. Long-term wise, the plugin needs some modernization to keep up with our common practices (no inline page modification (no inline CSS like in this case, no inline `<script>` blocks) and other items considered banned by our [Content-Security-Policy](https://www.jenkins.io/doc/book/security/configuring-content-security-policy/))