### PR TITLE
Use one-column layout

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
@@ -4,7 +4,7 @@ import java.net.URLEncoder;
 def l = namespace(lib.LayoutTagLib)
 def st = namespace("jelly:stapler")
 
-l.layout {
+l.layout(type: "one-column") {
     l.main_panel {
         h2(_("Embeddable Build Status Icon"))
         p(raw(_("blurb")))

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
@@ -4,7 +4,7 @@ import java.net.URLEncoder;
 def l = namespace(lib.LayoutTagLib)
 def st = namespace("jelly:stapler")
 
-l.layout {
+l.layout(type: "one-column") {
     l.main_panel {
         h2(_("Embeddable Build Status Icon"))
         p(raw(_("blurb")))


### PR DESCRIPTION
This PR introduces the one-column layout we already use for various pages in core, which don't have a sidebar, yet take up the space of a sidebar:

Before:
![Screenshot 2023-02-12 at 09 26 53](https://user-images.githubusercontent.com/13383509/218300639-4f93ad69-8f05-4161-a516-9bb5db37a8ae.png)

After:
![Screenshot 2023-02-12 at 09 27 07](https://user-images.githubusercontent.com/13383509/218300645-9b4f64e2-7cac-4de8-b296-e3b14c4208b6.png)