### PR TITLE
[JENKINS-70602] Do not overwrite system font on examples page

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/ClickHandler.js
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/ClickHandler.js
@@ -1,0 +1,8 @@
+Behaviour.register({
+  "INPUT.select-all" : function(e) {
+    e.onclick = function () {
+      e.focus();
+      e.select();
+    }
+  }
+});

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
@@ -9,7 +9,7 @@ l.layout {
         h2(_("Embeddable Build Status Icon"))
         p(raw(_("blurb")))
         st.adjunct(includes: "org.jenkinsci.plugins.badge.actions.JobBadgeAction.ClickHandler")
-        l.css(src: "${rootURL}/plugin/embeddable-build-status/css/design.css")
+        l.css(src: "/plugin/embeddable-build-status/css/design.css")
 
         def fullJobName = URLEncoder.encode(my.project.fullName, "UTF-8");
         def jobUrl =  "${app.rootUrl}${my.project.url}";

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
@@ -8,36 +8,8 @@ l.layout {
     l.main_panel {
         h2(_("Embeddable Build Status Icon"))
         p(raw(_("blurb")))
-        raw("""
-<p>
-</p>
-<script>
-    Behaviour.register({
-        "INPUT.select-all" : function(e) {
-            e.onclick = function () {
-                e.focus();
-                e.select();
-            }
-        }
-    });
-</script>
-<style>
-    INPUT {
-        font-family: Console, "Courier New", Courier, monospace;
-        border: none;
-        font-size: -2;
-    }
-    INPUT.select-all {
-        width:100%;
-    }
-    IMG#badge {
-        margin-left:2em;
-    }
-    h3 {
-        border-bottom: 1px solid grey;
-    }
-</style>
-""")
+        st.adjunct(includes: "org.jenkinsci.plugins.badge.actions.JobBadgeAction.ClickHandler")
+        l.css(src: "${rootURL}/plugin/embeddable-build-status/css/design.css")
 
         def fullJobName = URLEncoder.encode(my.project.fullName, "UTF-8");
         def jobUrl =  "${app.rootUrl}${my.project.url}";

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
@@ -9,7 +9,7 @@ l.layout {
         h2(_("Embeddable Build Status Icon"))
         p(raw(_("blurb")))
         st.adjunct(includes: "org.jenkinsci.plugins.badge.actions.JobBadgeAction.ClickHandler")
-        l.css(src: "${rootURL}/plugin/embeddable-build-status/css/design.css")
+        l.css(src: "/plugin/embeddable-build-status/css/design.css")
 
         def fullJobName = URLEncoder.encode(my.project.fullName, "UTF-8");
         def jobUrl =  "${app.rootUrl}${my.project.url}${my.run.number}/";

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
@@ -8,36 +8,8 @@ l.layout {
     l.main_panel {
         h2(_("Embeddable Build Status Icon"))
         p(raw(_("blurb")))
-        raw("""
-<p>
-</p>
-<script>
-    Behaviour.register({
-        "INPUT.select-all" : function(e) {
-            e.onclick = function () {
-                e.focus();
-                e.select();
-            }
-        }
-    });
-</script>
-<style>
-    INPUT {
-        font-family: Console, "Courier New", Courier, monospace;
-        border: none;
-        font-size: -2;
-    }
-    INPUT.select-all {
-        width:100%;
-    }
-    IMG#badge {
-        margin-left:2em;
-    }
-    h3 {
-        border-bottom: 1px solid grey;
-    }
-</style>
-""")
+        st.adjunct(includes: "org.jenkinsci.plugins.badge.actions.JobBadgeAction.ClickHandler")
+        l.css(src: "${rootURL}/plugin/embeddable-build-status/css/design.css")
 
         def fullJobName = URLEncoder.encode(my.project.fullName, "UTF-8");
         def jobUrl =  "${app.rootUrl}${my.project.url}${my.run.number}/";

--- a/src/main/webapp/css/design.css
+++ b/src/main/webapp/css/design.css
@@ -1,0 +1,14 @@
+INPUT {
+    border: none;
+    font-size: -2;
+}
+INPUT.select-all {
+    width:100%;
+    font-family: Console, "Courier New", Courier, monospace;
+}
+IMG#badge {
+    margin-left:2em;
+}
+h3 {
+    border-bottom: 1px solid grey;
+}


### PR DESCRIPTION
## [JENKINS-70602](https://issues.jenkins.io/browse/JENKINS-70602) - Do no overwrite system font on examples page

This PR picks up the last paragraph of #167 and removes inline page modification, but delivers the underlying change too.

JavaScript is now loaded via stapler adjuncts and page decoration has been moved to a dedicated CSS file loaded separately, as advised by our documentation.