### PR TITLE
Format code with Palantir Java Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,8 @@
             <!-- define a language-specific format -->
             <java>
               <!-- no need to specify files, inferred automatically -->
-              <!-- apply a specific flavor of google-java-format -->
-              <googleJavaFormat>
-                <version>1.15.0</version>
-                <style>AOSP</style>
-              </googleJavaFormat>
               <endWithNewline />
+              <palantirJavaFormat />
               <removeUnusedImports />
             </java>
             <pom>

--- a/src/main/java/org/jenkinsci/plugins/badge/EmbeddableBadgeConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/EmbeddableBadgeConfig.java
@@ -11,19 +11,18 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 public class EmbeddableBadgeConfig implements Serializable {
     private static final long serialVersionUID = 1L;
-    private final Map<String, String> colors =
-            new HashMap<String, String>() {
-                private static final long serialVersionUID = 1L;
+    private final Map<String, String> colors = new HashMap<String, String>() {
+        private static final long serialVersionUID = 1L;
 
-                {
-                    put("failing", "red");
-                    put("passing", "brightgreen");
-                    put("unstable", "yellow");
-                    put("aborted", "aborted");
-                    put("running", "blue");
-                }
-                ;
-            };
+        {
+            put("failing", "red");
+            put("passing", "brightgreen");
+            put("unstable", "yellow");
+            put("aborted", "aborted");
+            put("running", "blue");
+        }
+        ;
+    };
 
     private final String id;
     private String subject = null;

--- a/src/main/java/org/jenkinsci/plugins/badge/IconRequestHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/IconRequestHandler.java
@@ -21,14 +21,8 @@ public class IconRequestHandler {
     }
 
     public StatusImage handleIconRequest(
-            String style,
-            String subject,
-            String status,
-            String color,
-            String animatedOverlayColor,
-            String link) {
-        return iconResolver.getImage(
-                BallColor.BLUE, style, subject, status, color, animatedOverlayColor, link);
+            String style, String subject, String status, String color, String animatedOverlayColor, String link) {
+        return iconResolver.getImage(BallColor.BLUE, style, subject, status, color, animatedOverlayColor, link);
     }
 
     public StatusImage handleIconRequestForJob(
@@ -54,26 +48,36 @@ public class IconRequestHandler {
                             || color == null
                             || animatedOverlayColor == null
                             || link == null)) {
-                EmbeddableBadgeConfig badgeConfig =
-                        EmbeddableBadgeConfigsAction.resolve(job, config);
+                EmbeddableBadgeConfig badgeConfig = EmbeddableBadgeConfigsAction.resolve(job, config);
                 if (badgeConfig != null) {
-                    if (subject == null) subject = badgeConfig.getSubject();
-                    if (status == null) status = badgeConfig.getStatus();
-                    if (color == null) color = badgeConfig.getColor();
-                    if (animatedOverlayColor == null)
+                    if (subject == null) {
+                        subject = badgeConfig.getSubject();
+                    }
+                    if (status == null) {
+                        status = badgeConfig.getStatus();
+                    }
+                    if (color == null) {
+                        color = badgeConfig.getColor();
+                    }
+                    if (animatedOverlayColor == null) {
                         animatedOverlayColor = badgeConfig.getAnimatedOverlayColor();
-                    if (link == null) link = badgeConfig.getLink();
+                    }
+                    if (link == null) {
+                        link = badgeConfig.getLink();
+                    }
                 } else {
                     // fallback to unknown badge
-                    if (status == null) status = "not run";
-                    if (color == null) color = "lightgrey";
+                    if (status == null) {
+                        status = "not run";
+                    }
+                    if (color == null) {
+                        color = "lightgrey";
+                    }
                 }
             }
-            return iconResolver.getImage(
-                    job.getIconColor(), style, subject, status, color, animatedOverlayColor, link);
+            return iconResolver.getImage(job.getIconColor(), style, subject, status, color, animatedOverlayColor, link);
         } else {
-            return iconResolver.getImage(
-                    BallColor.NOTBUILT, style, subject, null, null, null, null);
+            return iconResolver.getImage(BallColor.NOTBUILT, style, subject, null, null, null, null);
         }
     }
 
@@ -100,26 +104,36 @@ public class IconRequestHandler {
                             || color == null
                             || animatedOverlayColor == null
                             || link == null)) {
-                EmbeddableBadgeConfig badgeConfig =
-                        EmbeddableBadgeConfigsAction.resolve(run, config);
+                EmbeddableBadgeConfig badgeConfig = EmbeddableBadgeConfigsAction.resolve(run, config);
                 if (badgeConfig != null) {
-                    if (subject == null) subject = badgeConfig.getSubject();
-                    if (status == null) status = badgeConfig.getStatus();
-                    if (color == null) color = badgeConfig.getColor();
-                    if (animatedOverlayColor == null)
+                    if (subject == null) {
+                        subject = badgeConfig.getSubject();
+                    }
+                    if (status == null) {
+                        status = badgeConfig.getStatus();
+                    }
+                    if (color == null) {
+                        color = badgeConfig.getColor();
+                    }
+                    if (animatedOverlayColor == null) {
                         animatedOverlayColor = badgeConfig.getAnimatedOverlayColor();
-                    if (link == null) link = badgeConfig.getLink();
+                    }
+                    if (link == null) {
+                        link = badgeConfig.getLink();
+                    }
                 } else {
                     // fallback to disabled badge
-                    if (status == null) status = "not run";
-                    if (color == null) color = "lightgrey";
+                    if (status == null) {
+                        status = "not run";
+                    }
+                    if (color == null) {
+                        color = "lightgrey";
+                    }
                 }
             }
-            return iconResolver.getImage(
-                    run.getIconColor(), style, subject, status, color, animatedOverlayColor, link);
+            return iconResolver.getImage(run.getIconColor(), style, subject, status, color, animatedOverlayColor, link);
         } else {
-            return iconResolver.getImage(
-                    BallColor.NOTBUILT, style, subject, null, null, null, null);
+            return iconResolver.getImage(BallColor.NOTBUILT, style, subject, null, null, null, null);
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/badge/ImageResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/ImageResolver.java
@@ -29,21 +29,20 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ImageResolver {
-    private final Map<String, String> statuses =
-            new HashMap<String, String>() {
-                private static final long serialVersionUID = 1L;
+    private final Map<String, String> statuses = new HashMap<String, String>() {
+        private static final long serialVersionUID = 1L;
 
-                {
-                    put("red", "failing");
-                    put("brightgreen", "passing");
-                    put("yellow", "unstable");
-                    put("aborted", "aborted");
-                    put("blue", "running");
-                    put("disabled", "disabled");
-                    put("notbuilt", "not run");
-                }
-                ;
-            };
+        {
+            put("red", "failing");
+            put("brightgreen", "passing");
+            put("yellow", "unstable");
+            put("aborted", "aborted");
+            put("blue", "running");
+            put("disabled", "disabled");
+            put("notbuilt", "not run");
+        }
+        ;
+    };
 
     public StatusImage getImage(
             BallColor color,
@@ -103,11 +102,8 @@ public class ImageResolver {
         }
 
         if (status == null) {
-            status =
-                    statuses.get(
-                            statusAnimatedOverlayColorName != null
-                                    ? statusAnimatedOverlayColorName
-                                    : statusColorName);
+            status = statuses.get(
+                    statusAnimatedOverlayColorName != null ? statusAnimatedOverlayColorName : statusColorName);
             if (status == null) {
                 status = "unknown";
             }

--- a/src/main/java/org/jenkinsci/plugins/badge/ParameterResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/ParameterResolver.java
@@ -27,13 +27,11 @@ public class ParameterResolver {
                     }
                 }
                 if (resolvedMatch != null) {
-                    parameter =
-                            matcher.replaceFirst(
-                                    resolvedMatch
-                                            .replace("\\", "\\\\")
-                                            .replace("$", "\\$")
-                                            .replace("{", "\\{")
-                                            .replace("}", "\\}"));
+                    parameter = matcher.replaceFirst(resolvedMatch
+                            .replace("\\", "\\\\")
+                            .replace("$", "\\$")
+                            .replace("{", "\\{")
+                            .replace("}", "\\}"));
                 } else {
                     parameter = matcher.replaceFirst("$1");
                 }

--- a/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
@@ -47,7 +47,7 @@ class StatusImage implements HttpResponse {
 
     private static final Jenkins jInstance = Jenkins.get();
     private static final PluginWrapper plugin = jInstance.pluginManager.getPlugin(PLGIN_NAME);
-    private static final URL baseUrl = (plugin != null ? plugin.baseResourceURL : null);
+    private static final URL baseUrl = plugin != null ? plugin.baseResourceURL : null;
 
     /**
      * To improve the caching, compute unique ETag.
@@ -60,22 +60,21 @@ class StatusImage implements HttpResponse {
     private final String length;
     private String contentType = null;
 
-    private final Map<String, String> colors =
-            new HashMap<String, String>() {
-                private static final long serialVersionUID = 1L;
+    private final Map<String, String> colors = new HashMap<String, String>() {
+        private static final long serialVersionUID = 1L;
 
-                {
-                    put("red", "#e05d44");
-                    put("brightgreen", "#44cc11");
-                    put("green", "#97CA00");
-                    put("yellowgreen", "#a4a61d");
-                    put("yellow", "#dfb317");
-                    put("orange", "#fe7d37");
-                    put("lightgrey", "#9f9f9f");
-                    put("blue", "#007ec6");
-                }
-                ;
-            };
+        {
+            put("red", "#e05d44");
+            put("brightgreen", "#44cc11");
+            put("green", "#97CA00");
+            put("yellowgreen", "#a4a61d");
+            put("yellow", "#dfb317");
+            put("orange", "#fe7d37");
+            put("lightgrey", "#9f9f9f");
+            put("blue", "#007ec6");
+        }
+        ;
+    };
 
     StatusImage() {
         etag = '"' + Jenkins.RESOURCE_PATH + '/' + "empty" + '"';
@@ -94,36 +93,28 @@ class StatusImage implements HttpResponse {
         length = Integer.toString(payload.length);
     }
 
-    StatusImage(
-            String subject,
-            String status,
-            String colorName,
-            String animatedColorName,
-            String style,
-            String link)
+    StatusImage(String subject, String status, String colorName, String animatedColorName, String style, String link)
             throws IOException {
         // escape URL parameters
-        if (subject != null) subject = StringEscapeUtils.escapeHtml(subject);
-        if (status != null) status = StringEscapeUtils.escapeHtml(status);
-        if (animatedColorName != null)
+        if (subject != null) {
+            subject = StringEscapeUtils.escapeHtml(subject);
+        }
+        if (status != null) {
+            status = StringEscapeUtils.escapeHtml(status);
+        }
+        if (animatedColorName != null) {
             animatedColorName = StringEscapeUtils.escapeHtml(animatedColorName);
-        if (colorName != null) colorName = StringEscapeUtils.escapeHtml(colorName);
-        if (link != null)
-            link =
-                    StringEscapeUtils.escapeHtml(
-                            StringEscapeUtils.escapeHtml(
-                                    link)); // double-escape because concatenating into an attribute
-        // effectively removes one level of quoting
+        }
+        if (colorName != null) {
+            colorName = StringEscapeUtils.escapeHtml(colorName);
+        }
+        if (link != null) {
+            // double-escape because concatenating into an attribute effectively removes one level of quoting
+            link = StringEscapeUtils.escapeHtml(StringEscapeUtils.escapeHtml(link));
+        }
 
         if (baseUrl != null) {
-            etag =
-                    Jenkins.RESOURCE_PATH
-                            + '/'
-                            + subject
-                            + status
-                            + colorName
-                            + animatedColorName
-                            + style;
+            etag = Jenkins.RESOURCE_PATH + '/' + subject + status + colorName + animatedColorName + style;
 
             if (style == null
                     || !Arrays.asList("flat-square", "plastic")
@@ -175,10 +166,9 @@ class StatusImage implements HttpResponse {
             if (animatedSnippet != null) {
                 String reducedStatusWidth = String.valueOf(widths[1] - 4.0);
                 try (InputStream animatedOverlayStream = animatedSnippet.openStream()) {
-                    animatedOverlay =
-                            IOUtils.toString(animatedOverlayStream, "utf-8")
-                                    .replace("{{reducedStatusWidth}}", reducedStatusWidth)
-                                    .replace("{{animatedColor}}", animatedColor);
+                    animatedOverlay = IOUtils.toString(animatedOverlayStream, "utf-8")
+                            .replace("{{reducedStatusWidth}}", reducedStatusWidth)
+                            .replace("{{animatedColor}}", animatedColor);
                 }
             }
 
@@ -187,10 +177,9 @@ class StatusImage implements HttpResponse {
                     URL url = new URL(link);
                     final String protocol = url.getProtocol();
                     if (protocol.equals("http") || protocol.equals("https")) {
-                        linkCode =
-                                "<svg onclick=\"window.open(&quot;"
-                                        + link
-                                        + "&quot;);\" style=\"cursor: pointer;\" xmlns";
+                        linkCode = "<svg onclick=\"window.open(&quot;"
+                                + link
+                                + "&quot;);\" style=\"cursor: pointer;\" xmlns";
                     } else {
                         LOGGER.log(Level.FINE, "Invalid link protocol: {0}", protocol);
                     }
@@ -200,19 +189,18 @@ class StatusImage implements HttpResponse {
             }
 
             try (InputStream s = image.openStream()) {
-                payload =
-                        IOUtils.toString(s, "utf-8")
-                                .replace("{{animatedOverlayColor}}", animatedOverlay)
-                                .replace("{{fullwidth}}", fullwidth)
-                                .replace("{{subjectWidth}}", subjectWidth)
-                                .replace("{{statusWidth}}", statusWidth)
-                                .replace("{{subjectPos}}", subjectPos)
-                                .replace("{{statusPos}}", statusPos)
-                                .replace("{{subject}}", subject)
-                                .replace("{{status}}", status)
-                                .replace("{{color}}", color)
-                                .replace("<svg xmlns", linkCode)
-                                .getBytes(Charset.forName("UTF-8"));
+                payload = IOUtils.toString(s, "utf-8")
+                        .replace("{{animatedOverlayColor}}", animatedOverlay)
+                        .replace("{{fullwidth}}", fullwidth)
+                        .replace("{{subjectWidth}}", subjectWidth)
+                        .replace("{{statusWidth}}", statusWidth)
+                        .replace("{{subjectPos}}", subjectPos)
+                        .replace("{{statusPos}}", statusPos)
+                        .replace("{{subject}}", subject)
+                        .replace("{{status}}", status)
+                        .replace("{{color}}", color)
+                        .replace("<svg xmlns", linkCode)
+                        .getBytes(Charset.forName("UTF-8"));
             }
 
             length = Integer.toString(payload.length);
@@ -238,8 +226,7 @@ class StatusImage implements HttpResponse {
                 Logger.getLogger(StatusImage.class.getName())
                         .log(Level.SEVERE, "Font format exception " + FONT_NAME, ex);
             } catch (IOException ex) {
-                Logger.getLogger(StatusImage.class.getName())
-                        .log(Level.SEVERE, "IOException reading " + FONT_NAME, ex);
+                Logger.getLogger(StatusImage.class.getName()).log(Level.SEVERE, "IOException reading " + FONT_NAME, ex);
             }
         } catch (MalformedURLException ex) {
             Logger.getLogger(StatusImage.class.getName())

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/EmbeddableBadgeConfigsAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/EmbeddableBadgeConfigsAction.java
@@ -21,28 +21,29 @@ import org.kohsuke.stapler.export.ExportedBean;
 @ExportedBean(defaultVisibility = 2)
 public class EmbeddableBadgeConfigsAction implements Action, Serializable, BuildBadgeAction {
     private static final long serialVersionUID = 1L;
-    private Map<String, EmbeddableBadgeConfig> badgeConfigs =
-            new HashMap<String, EmbeddableBadgeConfig>();
+    private Map<String, EmbeddableBadgeConfig> badgeConfigs = new HashMap<String, EmbeddableBadgeConfig>();
 
     public EmbeddableBadgeConfigsAction() {}
 
     /* Action methods */
+    @Override
     public String getUrlName() {
         return "";
     }
 
+    @Override
     public String getDisplayName() {
         return "";
     }
 
+    @Override
     public String getIconFileName() {
         return null;
     }
 
     public static EmbeddableBadgeConfig resolve(Run<?, ?> run, String id) {
         if (id != null) {
-            EmbeddableBadgeConfigsAction badgeConfigs =
-                    run.getAction(EmbeddableBadgeConfigsAction.class);
+            EmbeddableBadgeConfigsAction badgeConfigs = run.getAction(EmbeddableBadgeConfigsAction.class);
             if (badgeConfigs != null) {
                 return badgeConfigs.getConfig(id);
             }

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/JobBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/JobBadgeAction.java
@@ -35,10 +35,12 @@ public class JobBadgeAction implements Action, IconSpec {
         return "symbol-shield-outline plugin-ionicons-api";
     }
 
+    @Override
     public String getDisplayName() {
         return Messages.JobBadgeAction_DisplayName();
     }
 
+    @Override
     public String getUrlName() {
         return "badge";
     }

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/PublicBuildStatusAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/PublicBuildStatusAction.java
@@ -39,13 +39,8 @@ import org.kohsuke.stapler.WebMethod;
 @SuppressWarnings("rawtypes")
 @Extension
 public class PublicBuildStatusAction implements UnprotectedRootAction {
-    public static final Permission VIEW_STATUS =
-            new Permission(
-                    Item.PERMISSIONS,
-                    "ViewStatus",
-                    Messages._ViewStatus_Permission(),
-                    Item.READ,
-                    PermissionScope.ITEM);
+    public static final Permission VIEW_STATUS = new Permission(
+            Item.PERMISSIONS, "ViewStatus", Messages._ViewStatus_Permission(), Item.READ, PermissionScope.ITEM);
     private static final Jenkins jInstance = Jenkins.get();
     private IconRequestHandler iconRequestHandler;
 
@@ -110,25 +105,11 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
             @QueryParameter String animatedOverlayColor,
             @QueryParameter String config,
             @QueryParameter String link) {
-        return doIcon(
-                req,
-                rsp,
-                job,
-                build,
-                style,
-                subject,
-                status,
-                color,
-                animatedOverlayColor,
-                config,
-                link);
+        return doIcon(req, rsp, job, build, style, subject, status, color, animatedOverlayColor, config, link);
     }
 
     public String doText(
-            StaplerRequest req,
-            StaplerResponse rsp,
-            @QueryParameter String job,
-            @QueryParameter String build) {
+            StaplerRequest req, StaplerResponse rsp, @QueryParameter String job, @QueryParameter String build) {
         if (job == null) {
             return "Missing query parameter: job";
         }
@@ -150,8 +131,7 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
 
             try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
                 // first try to get Job via JobSelectorExtensionPoints
-                for (JobSelectorExtensionPoint jobSelector :
-                        ExtensionList.lookup(JobSelectorExtensionPoint.class)) {
+                for (JobSelectorExtensionPoint jobSelector : ExtensionList.lookup(JobSelectorExtensionPoint.class)) {
                     p = jobSelector.select(job);
                     if (p != null) {
                         break;
@@ -178,8 +158,7 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
     @SuppressFBWarnings(
             value = "NP_LOAD_OF_KNOWN_NULL_VALUE",
             justification = "'run' is only null for the first enclosing for(token) run")
-    public static Run<?, ?> getRun(
-            Job<?, ?> project, String build, Boolean throwErrorWhenNotFound) {
+    public static Run<?, ?> getRun(Job<?, ?> project, String build, Boolean throwErrorWhenNotFound) {
         Run<?, ?> run = null;
 
         if (project != null && build != null) {

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/RunBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/RunBadgeAction.java
@@ -32,10 +32,12 @@ public class RunBadgeAction implements Action, IconSpec {
         return "symbol-shield-outline plugin-ionicons-api";
     }
 
+    @Override
     public String getDisplayName() {
         return Messages.RunBadgeAction_DisplayName();
     }
 
+    @Override
     public String getUrlName() {
         return "badge";
     }

--- a/src/main/java/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep.java
@@ -116,9 +116,7 @@ public class AddEmbeddableBadgeConfigStep extends Step {
 
     public static class Execution extends SynchronousStepExecution<EmbeddableBadgeConfig> {
 
-        @SuppressFBWarnings(
-                value = "SE_TRANSIENT_FIELD_NOT_RESTORED",
-                justification = "Only used when starting.")
+        @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Only used when starting.")
         private final transient EmbeddableBadgeConfig badgeConfig;
 
         Execution(EmbeddableBadgeConfig badgeConfig, StepContext context) {

--- a/src/main/java/org/jenkinsci/plugins/badge/extensions/BuildIdRunSelectorExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/extensions/BuildIdRunSelectorExtension.java
@@ -12,6 +12,7 @@ import org.jenkinsci.plugins.badge.extensionpoints.InternalRunSelectorExtensionP
 @SuppressWarnings("rawtypes")
 @Extension
 public class BuildIdRunSelectorExtension implements InternalRunSelectorExtensionPoint {
+    @Override
     public Run select(Job project, String build, Run run) {
         Integer buildNr = 1;
         Boolean buildIdIsInteger = true;

--- a/src/main/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtension.java
@@ -17,9 +17,9 @@ import org.jenkinsci.plugins.badge.extensionpoints.ParameterResolverExtensionPoi
 @Extension
 public class BuildParameterResolverExtension implements ParameterResolverExtensionPoint {
     private static Pattern pattern = Pattern.compile("params\\.([^\\{\\}\\s]+)");
-    private static Pattern defaultPattern =
-            Pattern.compile("params\\.([^\\{\\}\\s\\|]+)\\|([^\\}\\|]+)");
+    private static Pattern defaultPattern = Pattern.compile("params\\.([^\\{\\}\\s\\|]+)\\|([^\\}\\|]+)");
 
+    @Override
     public String resolve(Actionable actionable, String parameter) {
         if (actionable instanceof Run) {
             Run<?, ?> run = (Run<?, ?>) actionable;
@@ -35,12 +35,10 @@ public class BuildParameterResolverExtension implements ParameterResolverExtensi
                     if (val != null) {
                         // replace ${params.<ParamName>|<DefaultValue>} with the value
                         String valueStr = val.toString();
-                        parameter =
-                                matcher.replaceAll(
-                                        valueStr.replace("\\", "\\\\")
-                                                .replace("$", "\\$")
-                                                .replace("{", "\\{")
-                                                .replace("}", "\\}"));
+                        parameter = matcher.replaceAll(valueStr.replace("\\", "\\\\")
+                                .replace("$", "\\$")
+                                .replace("{", "\\{")
+                                .replace("}", "\\}"));
                         matcher = defaultPattern.matcher(parameter);
                     } else {
                         // replace ${params.<ParamName>|<DefaultValue>} with the <DefaultValue>
@@ -58,12 +56,10 @@ public class BuildParameterResolverExtension implements ParameterResolverExtensi
                     if (val != null) {
                         // replace ${params.<ParamName>} with the value
                         String valueStr = val.toString();
-                        parameter =
-                                matcher.replaceFirst(
-                                        valueStr.replace("\\", "\\\\")
-                                                .replace("$", "\\$")
-                                                .replace("{", "\\{")
-                                                .replace("}", "\\}"));
+                        parameter = matcher.replaceFirst(valueStr.replace("\\", "\\\\")
+                                .replace("$", "\\$")
+                                .replace("{", "\\{")
+                                .replace("}", "\\}"));
                         matcher = pattern.matcher(parameter);
                     } else {
                         // replace ${params.<ParamName>} with empty string

--- a/src/main/java/org/jenkinsci/plugins/badge/extensions/BuildParameterRunSelectorExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/extensions/BuildParameterRunSelectorExtension.java
@@ -17,9 +17,8 @@ import org.jenkinsci.plugins.badge.extensionpoints.InternalRunSelectorExtensionP
 @SuppressWarnings("rawtypes")
 @Extension
 public class BuildParameterRunSelectorExtension implements InternalRunSelectorExtensionPoint {
-    private static Pattern outerSelector =
-            Pattern.compile(
-                    "(last|first)(Failed|Successful|Unsuccessful|Stable|Unstable|Completed){0,1}(:\\$\\{([^\\{\\}\\s]+)\\}){0,1}");
+    private static Pattern outerSelector = Pattern.compile(
+            "(last|first)(Failed|Successful|Unsuccessful|Stable|Unstable|Completed){0,1}(:\\$\\{([^\\{\\}\\s]+)\\}){0,1}");
     private static Pattern paramsPattern = Pattern.compile("params\\.([^=]+)=(.*)");
 
     private Boolean matchRule(Job job, Run run, String rule) {
@@ -81,7 +80,7 @@ public class BuildParameterRunSelectorExtension implements InternalRunSelectorEx
                 }
 
                 if (run != null) {
-                    Boolean doBreak = (specific == null);
+                    Boolean doBreak = specific == null;
                     if (!doBreak) {
                         Result result = run.getResult();
                         if (result != null) {
@@ -92,23 +91,12 @@ public class BuildParameterRunSelectorExtension implements InternalRunSelectorEx
                             Boolean isUnsuccessful = !isSuccessful;
                             Boolean isStable = isSuccessful;
 
-                            doBreak =
-                                    (specific.equals("Completed") && isCompleted)
-                                            || (specific.equals("Successful")
-                                                    && isCompleted
-                                                    && isSuccessful)
-                                            || (specific.equals("Failed")
-                                                    && isCompleted
-                                                    && isFailed)
-                                            || (specific.equals("Unstable")
-                                                    && isCompleted
-                                                    && isUnstable)
-                                            || (specific.equals("Unsuccessful")
-                                                    && isCompleted
-                                                    && isUnsuccessful)
-                                            || (specific.equals("Stable")
-                                                    && isCompleted
-                                                    && isStable);
+                            doBreak = (specific.equals("Completed") && isCompleted)
+                                    || (specific.equals("Successful") && isCompleted && isSuccessful)
+                                    || (specific.equals("Failed") && isCompleted && isFailed)
+                                    || (specific.equals("Unstable") && isCompleted && isUnstable)
+                                    || (specific.equals("Unsuccessful") && isCompleted && isUnsuccessful)
+                                    || (specific.equals("Stable") && isCompleted && isStable);
                         }
                     }
 
@@ -121,6 +109,7 @@ public class BuildParameterRunSelectorExtension implements InternalRunSelectorEx
         return run;
     }
 
+    @Override
     public Run select(Job job, String runId, Run run) {
         Matcher matcher = outerSelector.matcher(runId);
         while (matcher.find()) {

--- a/src/main/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtension.java
@@ -14,6 +14,7 @@ import org.jenkinsci.plugins.badge.extensionpoints.ParameterResolverExtensionPoi
 @Extension
 public class SpecialValueParameterResolverExtension implements ParameterResolverExtensionPoint {
 
+    @Override
     public String resolve(Actionable actionable, String parameter) {
         if (parameter != null) {
             if (actionable instanceof Run<?, ?>) {
@@ -27,14 +28,13 @@ public class SpecialValueParameterResolverExtension implements ParameterResolver
                     ${startTime}
                 */
 
-                parameter =
-                        parameter
-                                .replace("buildId", run.getId())
-                                .replace("buildNumber", Integer.toString(run.getNumber()))
-                                .replace("duration", run.getDurationString())
-                                .replace("description", Objects.toString(run.getDescription(), ""))
-                                .replace("displayName", run.getDisplayName())
-                                .replace("startTime", run.getTimestampString());
+                parameter = parameter
+                        .replace("buildId", run.getId())
+                        .replace("buildNumber", Integer.toString(run.getNumber()))
+                        .replace("duration", run.getDurationString())
+                        .replace("description", Objects.toString(run.getDescription(), ""))
+                        .replace("displayName", run.getDisplayName())
+                        .replace("startTime", run.getTimestampString());
 
             } else if (actionable instanceof Job<?, ?>) {
                 parameter = resolve(((Job<?, ?>) actionable).getLastBuild(), parameter);

--- a/src/test/java/org/jenkinsci/plugins/badge/EmbeddableBadgeConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/EmbeddableBadgeConfigTest.java
@@ -22,23 +22,15 @@ public class EmbeddableBadgeConfigTest {
 
     @Test
     public void testGetAnimatedOverlayColorBlueForRunning() {
-        EmbeddableBadgeConfig embeddableBadgeConfig =
-                new EmbeddableBadgeConfig("testId-running-blue");
+        EmbeddableBadgeConfig embeddableBadgeConfig = new EmbeddableBadgeConfig("testId-running-blue");
         embeddableBadgeConfig.setStatus("running");
         assertThat(embeddableBadgeConfig.getAnimatedOverlayColor(), is("blue"));
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "failing,red",
-        "passing,brightgreen",
-        "unstable,yellow",
-        "aborted,aborted",
-        "running,blue"
-    })
+    @CsvSource({"failing,red", "passing,brightgreen", "unstable,yellow", "aborted,aborted", "running,blue"})
     public void testGetColor(String status, String expected) {
-        EmbeddableBadgeConfig embeddableBadgeConfig =
-                new EmbeddableBadgeConfig("testId-status-" + status);
+        EmbeddableBadgeConfig embeddableBadgeConfig = new EmbeddableBadgeConfig("testId-status-" + status);
         embeddableBadgeConfig.setStatus(status);
         assertThat(embeddableBadgeConfig.getColor(), is(expected));
     }

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -14,9 +14,11 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 public class ImageResolverTest {
 
-    @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
 
-    @Rule public TestName testName = new TestName();
+    @Rule
+    public TestName testName = new TestName();
 
     @Test
     public void TestGetDefault32x32Ball() throws Exception {
@@ -26,13 +28,10 @@ public class ImageResolverTest {
         String status = getStatus();
         String colorName = null;
         BallColor ball = BallColor.BLUE;
-        StatusImage image =
-                wc.executeOnServer(
-                        () -> {
-                            ImageResolver imageResolver = new ImageResolver();
-                            return imageResolver.getImage(
-                                    ball, style, subject, status, colorName, null, null);
-                        });
+        StatusImage image = wc.executeOnServer(() -> {
+            ImageResolver imageResolver = new ImageResolver();
+            return imageResolver.getImage(ball, style, subject, status, colorName, null, null);
+        });
         assertThat(image.getEtag(), containsString(subject));
         assertThat(image.getEtag(), containsString(status));
         assertThat(image.getEtag(), containsString("null"));
@@ -47,17 +46,13 @@ public class ImageResolverTest {
         String status = getStatus();
         BallColor ball = BallColor.RED;
         String colorName = ball.toString();
-        StatusImage image =
-                wc.executeOnServer(
-                        () -> {
-                            ImageResolver imageResolver = new ImageResolver();
-                            return imageResolver.getImage(
-                                    ball, style, subject, status, colorName, null, null);
-                        });
+        StatusImage image = wc.executeOnServer(() -> {
+            ImageResolver imageResolver = new ImageResolver();
+            return imageResolver.getImage(ball, style, subject, status, colorName, null, null);
+        });
         assertThat(image.getEtag(), not(containsString(subject)));
         assertThat(image.getEtag(), not(containsString(status)));
-        assertThat(
-                image.getEtag(), containsString("images/" + sizeHint + "/" + colorName + ".png"));
+        assertThat(image.getEtag(), containsString("images/" + sizeHint + "/" + colorName + ".png"));
     }
 
     @Test
@@ -68,13 +63,10 @@ public class ImageResolverTest {
         String status = getStatus();
         String colorName = null;
         BallColor ball = BallColor.BLUE;
-        StatusImage image =
-                wc.executeOnServer(
-                        () -> {
-                            ImageResolver imageResolver = new ImageResolver();
-                            return imageResolver.getImage(
-                                    ball, style, subject, status, colorName, null, null);
-                        });
+        StatusImage image = wc.executeOnServer(() -> {
+            ImageResolver imageResolver = new ImageResolver();
+            return imageResolver.getImage(ball, style, subject, status, colorName, null, null);
+        });
         assertThat(image.getEtag(), not(containsString(subject)));
         assertThat(image.getEtag(), not(containsString(status)));
         assertThat(image.getEtag(), containsString("empty"));
@@ -99,8 +91,7 @@ public class ImageResolverTest {
     };
 
     private BallColor getJobStatusColor() {
-        return jobStatusColors[
-                random.nextInt(jobStatusColors.length)]; // A job status animated color
+        return jobStatusColors[random.nextInt(jobStatusColors.length)]; // A job status animated color
     }
 
     private BallColor[] animatedColors = {
@@ -108,8 +99,7 @@ public class ImageResolverTest {
     };
 
     private BallColor getAnimatedColor() {
-        return animatedColors[
-                random.nextInt(animatedColors.length)]; // An animated color with specific meaning
+        return animatedColors[random.nextInt(animatedColors.length)]; // An animated color with specific meaning
     }
 
     /* Any one of these colors will result in a lightgrey colored image */
@@ -123,8 +113,7 @@ public class ImageResolverTest {
     };
 
     private BallColor getLightGreyBallColor() {
-        return lightGreyEquivalents[
-                random.nextInt(lightGreyEquivalents.length)]; // A light grey equivalent ball color
+        return lightGreyEquivalents[random.nextInt(lightGreyEquivalents.length)]; // A light grey equivalent ball color
     }
 
     @Test
@@ -138,8 +127,7 @@ public class ImageResolverTest {
         String link = null; // "https://www.example.com/my-link";
         ImageResolver imageResolver = new ImageResolver();
         StatusImage image =
-                imageResolver.getImage(
-                        color, style, subject, status, colorName, animatedOverlayColor, link);
+                imageResolver.getImage(color, style, subject, status, colorName, animatedOverlayColor, link);
         assertThat(image.getEtag(), containsString(subject));
         assertThat(image.getEtag(), containsString(status));
         assertThat(image.getEtag(), containsString(colorName));
@@ -158,8 +146,7 @@ public class ImageResolverTest {
         String link = null;
         ImageResolver imageResolver = new ImageResolver();
         StatusImage image =
-                imageResolver.getImage(
-                        color, style, subject, status, colorName, animatedOverlayColor, link);
+                imageResolver.getImage(color, style, subject, status, colorName, animatedOverlayColor, link);
         assertThat(image.getEtag(), containsString(subject));
         assertThat(image.getEtag(), containsString(status));
         assertThat(image.getEtag(), containsString("lightgrey")); // Not built color
@@ -179,8 +166,7 @@ public class ImageResolverTest {
         String link = null; // "https://www.example.com/my-link";
         ImageResolver imageResolver = new ImageResolver();
         StatusImage image =
-                imageResolver.getImage(
-                        color, style, subject, status, colorName, animatedOverlayColor, link);
+                imageResolver.getImage(color, style, subject, status, colorName, animatedOverlayColor, link);
         assertThat(image.getEtag(), containsString(subject));
         assertThat(image.getEtag(), containsString(status));
         assertThat(image.getEtag(), containsString("lightgrey")); // Not built color

--- a/src/test/java/org/jenkinsci/plugins/badge/ParameterResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ParameterResolverTest.java
@@ -16,8 +16,7 @@ class ParameterResolverTest {
         "Build ${params.BUILD_BRANCH|master} (${displayName}),Build params.BUILD_BRANCH|master (displayName)"
     })
     void shouldResolveSubjectWithVariables(String queryParameter, String expectedParameter) {
-        String resolvedParameter =
-                new ParameterResolver().resolve(Mockito.mock(Actionable.class), queryParameter);
+        String resolvedParameter = new ParameterResolver().resolve(Mockito.mock(Actionable.class), queryParameter);
         assertThat(resolvedParameter, is(expectedParameter));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -34,7 +34,8 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 public class StatusImageTest {
 
-    @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
 
     public StatusImageTest() {}
 
@@ -66,15 +67,13 @@ public class StatusImageTest {
         String animatedColorName = null;
         String style = null;
         String link = null;
-        StatusImage statusImage =
-                new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
         assertThat(statusImage.getEtag(), containsString(subject));
         assertThat(statusImage.getEtag(), containsString(status));
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(
-                Integer.parseInt(statusImage.getLength()), allOf(greaterThan(920), lessThan(960)));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(920), lessThan(960)));
     }
 
     @Test
@@ -85,16 +84,14 @@ public class StatusImageTest {
         String animatedColorName = null;
         String style = "plastic";
         String link = null;
-        StatusImage statusImage =
-                new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
         assertThat(statusImage.getEtag(), containsString(subject));
         assertThat(statusImage.getEtag(), containsString(status));
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(
-                Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
     }
 
     @Test
@@ -105,8 +102,7 @@ public class StatusImageTest {
         String animatedColorName = "fe7d37";
         String style = "plastic";
         String link = null;
-        StatusImage statusImage =
-                new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
         assertThat(statusImage.getEtag(), containsString(subject));
         assertThat(statusImage.getEtag(), containsString(status));
         assertThat(statusImage.getEtag(), containsString(colorName));
@@ -114,22 +110,18 @@ public class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(animatedColorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(
-                Integer.parseInt(statusImage.getLength()),
-                allOf(greaterThan(1237), lessThan(1297)));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(1237), lessThan(1297)));
     }
 
     @Test
-    public void testConstructorFailingBuildPlasticStyleNumericColorAnimatedNumericColor()
-            throws Exception {
+    public void testConstructorFailingBuildPlasticStyleNumericColorAnimatedNumericColor() throws Exception {
         String subject = "build";
         String status = "failing";
         String colorName = "ff0000";
         String animatedColorName = "fe7d37";
         String style = "plastic";
         String link = null;
-        StatusImage statusImage =
-                new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
         assertThat(statusImage.getEtag(), containsString(subject));
         assertThat(statusImage.getEtag(), containsString(status));
         assertThat(statusImage.getEtag(), containsString(colorName));
@@ -137,9 +129,7 @@ public class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(animatedColorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(
-                Integer.parseInt(statusImage.getLength()),
-                allOf(greaterThan(1237), lessThan(1297)));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(1237), lessThan(1297)));
     }
 
     @Test
@@ -150,8 +140,7 @@ public class StatusImageTest {
         String animatedColorName = "yellow";
         String style = "plastic";
         String link = null;
-        StatusImage statusImage =
-                new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
         assertThat(statusImage.getEtag(), containsString(subject));
         assertThat(statusImage.getEtag(), containsString(status));
         assertThat(statusImage.getEtag(), containsString(colorName));
@@ -159,9 +148,7 @@ public class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(animatedColorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(
-                Integer.parseInt(statusImage.getLength()),
-                allOf(greaterThan(1237), lessThan(1297)));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(1237), lessThan(1297)));
     }
 
     @Test
@@ -172,16 +159,14 @@ public class StatusImageTest {
         String animatedColorName = null;
         String style = "plastic";
         String link = null;
-        StatusImage statusImage =
-                new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
         assertThat(statusImage.getEtag(), containsString(subject));
         assertThat(statusImage.getEtag(), containsString(status));
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(
-                Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
     }
 
     @Test
@@ -192,16 +177,14 @@ public class StatusImageTest {
         String animatedColorName = null;
         String style = "plastic";
         String link = null;
-        StatusImage statusImage =
-                new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
         assertThat(statusImage.getEtag(), containsString(subject));
         assertThat(statusImage.getEtag(), containsString(status));
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(
-                Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
     }
 
     @Test
@@ -212,16 +195,14 @@ public class StatusImageTest {
         String animatedColorName = null;
         String style = "flat-square";
         String link = null;
-        StatusImage statusImage =
-                new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
         assertThat(statusImage.getEtag(), containsString(subject));
         assertThat(statusImage.getEtag(), containsString(status));
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(
-                Integer.parseInt(statusImage.getLength()), allOf(greaterThan(510), lessThan(540)));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(510), lessThan(540)));
     }
 
     @Test
@@ -232,16 +213,14 @@ public class StatusImageTest {
         String animatedColorName = null;
         String style = "flat-square";
         String link = null;
-        StatusImage statusImage =
-                new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
         assertThat(statusImage.getEtag(), containsString(subject));
         assertThat(statusImage.getEtag(), containsString(status));
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(
-                Integer.parseInt(statusImage.getLength()), allOf(greaterThan(510), lessThan(540)));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(510), lessThan(540)));
     }
 
     @Test
@@ -252,15 +231,13 @@ public class StatusImageTest {
         String animatedColorName = null;
         String style = null;
         String link = null;
-        StatusImage statusImage =
-                new StatusImage(subject, status, colorName, animatedColorName, style, link);
+        StatusImage statusImage = new StatusImage(subject, status, colorName, animatedColorName, style, link);
         assertThat(statusImage.getEtag(), containsString(subject));
         assertThat(statusImage.getEtag(), containsString(status));
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(
-                Integer.parseInt(statusImage.getLength()), allOf(greaterThan(875), lessThan(925)));
+        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(875), lessThan(925)));
     }
 
     // private static final String PNG_CONTENT_TYPE = "image/png";

--- a/src/test/java/org/jenkinsci/plugins/badge/actions/PublicBuildStatusActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/actions/PublicBuildStatusActionTest.java
@@ -23,9 +23,11 @@ public class PublicBuildStatusActionTest {
 
     // JenkinsRule startup cost is high on Windows
     // Use a ClassRule to create one JenkinsRule used by all tests
-    @ClassRule public static JenkinsRule j = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
 
-    @Rule public TestName name = new TestName();
+    @Rule
+    public TestName name = new TestName();
 
     private static final String SUCCESS_MARKER = "fill=\"#44cc11\"";
     private static final String NOT_RUN_MARKER = "fill=\"#9f9f9f\"";

--- a/src/test/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtensionTest.java
@@ -70,8 +70,7 @@ class SpecialValueParameterResolverExtensionTest {
     @Test
     void testMultipleParameters() {
         String actualParameter =
-                extension.resolve(
-                        mockRun, "buildId buildNumber duration startTime displayName description");
+                extension.resolve(mockRun, "buildId buildNumber duration startTime displayName description");
         assertThat(actualParameter, is("1234 1234 23:35 23:35 display name run description"));
     }
 }


### PR DESCRIPTION
Google Java Format is an excellent formatter for 2-space, 100 line codebases. Its [Rectangle Rule](https://github.com/google/google-java-format/wiki/The-Rectangle-Rule) has a high degree of conceptual purity, and this works well in the context of 2-space, 100 line codebases where it was designed. If starting from scratch, or if radical changes to existing code style were on the table, this would be my ideal formatter.

For existing 4-space, 120 line codebases where radical changes to existing code style are not on the table, Google Java Format has some critical flaws. Its 4-space "AOSP" mode does not work well at all, and it was not the primary use case. In practice the combination of 4-space mode and the rectangle rule results in unreadable code for lambdas. I have complained about this on the Google Java Format issue tracker for years, but no fix appears to be on the horizon. This makes sense, because Google internally uses the 2-space non-AOSP mode. While various PRs have been submitted to fix this problem, the maintainers of Google Java Format have rejected or ignored them, likely because they all violate the conceptual purity of the Rectangle Rule.

For existing 4-space, 120 line codebases (and the Jenkins project consists largely of these) where radical changes to existing code style are not on the table, Palantir Java Format is a better choice than Google Java Format. It is a fork of Google Java Format designed for this use case with intentional violations of the Rectangle Rule. In practice it gives much better results than Google Java Format for this type of codebase.

The Maven project is reformatting its legacy codebase with Palantir Java Format and I have been impressed with how relatively uneventful it has been. Palantir Java Format works very well with this type of codebase, and Jenkins is an example of this type of codebase as well. I have successfully reformatted `plugin-compat-tester` this way in https://github.com/jenkinsci/plugin-compat-tester/pull/506 and the results are far better than Google Java Format.

As the Zen of Python states:

> Practicality beats purity.