### PR TITLE
Adapt 'l.css' removal in Jenkins 2.401 onwards

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
@@ -9,7 +9,7 @@ l.layout(type: "one-column") {
         h2(_("Embeddable Build Status Icon"))
         p(raw(_("blurb")))
         st.adjunct(includes: "org.jenkinsci.plugins.badge.actions.JobBadgeAction.ClickHandler")
-        l.css(src: "/plugin/embeddable-build-status/css/design.css")
+        link(rel: "stylesheet", href: "${rootURL}/plugin/embeddable-build-status/css/design.css", type: "text/css")
 
         def fullJobName = URLEncoder.encode(my.project.fullName, "UTF-8");
         def jobUrl =  "${app.rootUrl}${my.project.url}";

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
@@ -9,7 +9,7 @@ l.layout(type: "one-column") {
         h2(_("Embeddable Build Status Icon"))
         p(raw(_("blurb")))
         st.adjunct(includes: "org.jenkinsci.plugins.badge.actions.JobBadgeAction.ClickHandler")
-        l.css(src: "/plugin/embeddable-build-status/css/design.css")
+        link(rel: "stylesheet", href: "${rootURL}/plugin/embeddable-build-status/css/design.css", type: "text/css")
 
         def fullJobName = URLEncoder.encode(my.project.fullName, "UTF-8");
         def jobUrl =  "${app.rootUrl}${my.project.url}${my.run.number}/";


### PR DESCRIPTION
In 2.401, we have removed `l:css` from core, when we dropped the dependency on `jenkins-js-modules`. Therefore, `l.css`, the groovy equivalent, is gone too, but it appears the two plugins using groovy views weren't updated.
Hence, I'm filing this PR retrospectively.

Without my change proposed, the embeddable build status page looks like:
![Screenshot 2023-07-01 at 20 09 54](https://github.com/jenkinsci/embeddable-build-status-plugin/assets/13383509/10dc4bdf-28c2-4d62-aa23-3497ef72df54)
as you can see it on ci.jenkins.io and 2.401.x

In groovy, `link` is equal to the HTML tag `<link>`, this PR makes use of, working independently of Jenkins versions.