### PR TITLE
Match dependabot definition to GitHub docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,23 @@
+# Per https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-  - package-ecosystem: maven
-    directory: /
+
+  # Maintain dependencies for maven
+  - package-ecosystem: "maven"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
     open-pull-requests-limit: 10
-    target-branch: master
+    target-branch: "master"
     reviewers:
-      - MarkEWaite
+      - "MarkEWaite"
     labels:
-      - dependencies
-  - package-ecosystem: github-actions
-    directory: /
+      - "dependencies"
+
+  # Maintain dependencies for GitHub actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: monthly
+      interval: "monthly"
     labels:
-      - skip-changelog
+      - "skip-changelog"


### PR DESCRIPTION
## Match dependabot definition to GitHub docs

Use a consistent dependabot definition based on the GitHub documentation and commonly used labels.  Standard is better than better.

### Testing done

Base behavior was verified in https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin/pull/155

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
