### PR TITLE
Improve spacing of examples

### DIFF
--- a/src/main/webapp/css/design.css
+++ b/src/main/webapp/css/design.css
@@ -9,6 +9,12 @@ INPUT.select-all {
 IMG#badge {
     margin-left:2em;
 }
+h2 {
+    margin-bottom: 1px;
+    margin-top: 1em;
+}
 h3 {
     border-bottom: 1px solid grey;
+    margin-bottom: 1px;
+    margin-top: 1em;
 }


### PR DESCRIPTION
# Improve spacing of examples

Make the examples more readable by placing the example text immediately below its matching heading and by placing additional spacing above the heading.

I'd love to have better recommendations from those who know the Jenkins layout patterns better.  It is odd that the plugin uses an input field without a border in order to make the text easy to copy.  Would it be better to use the copy icon that is becoming available in more and more Jenkins pages?  Is there another way to make the text easily copied?

## Testing done

Confirmed with interactive testing that the page looks better after the change than before the change.

### Before

Page looked like this before:

![before](https://github.com/jenkinsci/embeddable-build-status-plugin/assets/156685/f642e15e-c77d-4765-b991-6c7a2788b325)

### After

Page looks like this after:

![after](https://github.com/jenkinsci/embeddable-build-status-plugin/assets/156685/226eebd0-1c16-43a3-ad92-9d97dfba2c7b)

### Production sample

See the pages on ci.jenkins.io for a production sample of the "before" state.  For example:

* [Plugin bill of materials master branch](https://ci.jenkins.io/job/Tools/job/bom/job/master/badge/)
* [Jenkins core master branch](https://ci.jenkins.io/job/Core/job/jenkins/job/master/badge/)

## Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
