### PR TITLE
Add asciidoc example to documentation page

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.groovy
@@ -65,6 +65,12 @@ l.layout(type: "one-column") {
         b {text(_("unprotected"))}
         input(type:"text",value:"[![Build Status](${publicBadge})](${jobUrl})",class:"select-all")
 
+        h3(_("Asciidoc"))
+        b {text(_("protected"))}
+        input(type:"text",value:"image:${badgeUrl}[link='${jobUrl}']",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"image:${publicBadge})[link='${jobUrl}']",class:"select-all")
+
         h3(_("HTML"))
         b {text(_("protected"))}
         input(type:"text",value:"<a href='${jobUrl}'><img src='${badgeUrl}'></a>",class:"select-all")

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.groovy
@@ -65,6 +65,12 @@ l.layout(type: "one-column") {
         b {text(_("unprotected"))}
         input(type:"text",value:"[![Build Status](${publicBadge})](${jobUrl})",class:"select-all")
 
+        h3(_("Asciidoc"))
+        b {text(_("protected"))}
+        input(type:"text",value:"image:${badgeUrl}[link='${jobUrl}']",class:"select-all")
+        b {text(_("unprotected"))}
+        input(type:"text",value:"image:${publicBadge})[link='${jobUrl}']",class:"select-all")
+
         h3(_("HTML"))
         b {text(_("protected"))}
         input(type:"text",value:"<a href='${jobUrl}'><img src='${badgeUrl}'></a>",class:"select-all")


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/embeddable-build-status-plugin/issues/59

Provide examples in Asciidoc format for users like me that prefer to create our documentation in Asciidoc.
