### PR TITLE
[JENKINS-70464] Test `AddEmbeddableBadgeConfigStep`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStepTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.jupiter.api.Assertions.*;
 
 public class AddEmbeddableBadgeConfigStepTest {
     @Test

--- a/src/test/java/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStepTest.java
@@ -1,15 +1,16 @@
 package org.jenkinsci.plugins.badge.dsl;
 
-import org.junit.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 
+import org.junit.Test;
+
 public class AddEmbeddableBadgeConfigStepTest {
     @Test
     public void testConstructor() {
-        AddEmbeddableBadgeConfigStep addEmbeddableBadgeConfigStep = new AddEmbeddableBadgeConfigStep("test-Id-constructor");
+        AddEmbeddableBadgeConfigStep addEmbeddableBadgeConfigStep =
+                new AddEmbeddableBadgeConfigStep("test-Id-constructor");
         assertThat(addEmbeddableBadgeConfigStep.getID(), is("test-Id-constructor"));
         assertThat(addEmbeddableBadgeConfigStep.getSubject(), is(nullValue()));
         assertThat(addEmbeddableBadgeConfigStep.getStatus(), is(nullValue()));
@@ -19,9 +20,9 @@ public class AddEmbeddableBadgeConfigStepTest {
     }
 
     @Test
-    public void testGetAnimatedOverlayColor(){
-        AddEmbeddableBadgeConfigStep addEmbeddableBadgeConfigStep = new AddEmbeddableBadgeConfigStep("test-animated-overlay-color");
-        assertThat(addEmbeddableBadgeConfigStep.getColor(),is(nullValue()));
+    public void testGetAnimatedOverlayColor() {
+        AddEmbeddableBadgeConfigStep addEmbeddableBadgeConfigStep =
+                new AddEmbeddableBadgeConfigStep("test-animated-overlay-color");
+        assertThat(addEmbeddableBadgeConfigStep.getColor(), is(nullValue()));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStepTest.java
@@ -1,0 +1,28 @@
+package org.jenkinsci.plugins.badge.dsl;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AddEmbeddableBadgeConfigStepTest {
+    @Test
+    public void testConstructor() {
+        AddEmbeddableBadgeConfigStep addEmbeddableBadgeConfigStep = new AddEmbeddableBadgeConfigStep("test-Id-constructor");
+        assertThat(addEmbeddableBadgeConfigStep.getID(), is("test-Id-constructor"));
+        assertThat(addEmbeddableBadgeConfigStep.getSubject(), is(nullValue()));
+        assertThat(addEmbeddableBadgeConfigStep.getStatus(), is(nullValue()));
+        assertThat(addEmbeddableBadgeConfigStep.getColor(), is(nullValue()));
+        assertThat(addEmbeddableBadgeConfigStep.getAnimatedOverlayColor(), is(nullValue()));
+        assertThat(addEmbeddableBadgeConfigStep.getLink(), is(nullValue()));
+    }
+
+    @Test
+    public void testGetAnimatedOverlayColor(){
+        AddEmbeddableBadgeConfigStep addEmbeddableBadgeConfigStep = new AddEmbeddableBadgeConfigStep("test-animated-overlay-color");
+        assertThat(addEmbeddableBadgeConfigStep.getColor(),is(nullValue()));
+    }
+
+}


### PR DESCRIPTION
In response #114, 

### Testing done

- `AddEmbeddableBadgeConfigStepTest.java`
- currently, test coverage is as shown below

![Screenshot 2023-10-02 200258](https://github.com/jenkinsci/embeddable-build-status-plugin/assets/14294846/e93cc46c-444a-457d-a7c0-ac711733ccdb)

After changes, test coverage stands as shown below

![Screenshot 2023-10-02 195611](https://github.com/jenkinsci/embeddable-build-status-plugin/assets/14294846/84a87bd0-a31f-41db-bcad-8e6e8c2ea64d)

<!-- Comment:


Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
