### PR TITLE
Prefer non-wildcard imports, even for tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/badge/EmbeddableBadgeConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/EmbeddableBadgeConfigTest.java
@@ -1,7 +1,8 @@
 package org.jenkinsci.plugins.badge;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/ImageResolverTest.java
@@ -1,7 +1,9 @@
 package org.jenkinsci.plugins.badge;
 
-import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import hudson.model.BallColor;
 import java.io.IOException;

--- a/src/test/java/org/jenkinsci/plugins/badge/JobBadgeActionFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/JobBadgeActionFactoryTest.java
@@ -1,7 +1,8 @@
 package org.jenkinsci.plugins.badge;
 
-import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 
 import hudson.model.Action;
 import hudson.model.Job;

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -23,9 +23,11 @@
  */
 package org.jenkinsci.plugins.badge;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 
 import org.junit.ClassRule;


### PR DESCRIPTION
## Prefer non-wildcard imports, even in tests

The wildcard imoprt is more difficult to read.

Thanks to OpenRewrite for the steps that started this change.

https://docs.openrewrite.org/recipes/java/testing/junit5/usehamcrestassertthat

### Testing done

Confirmed tests pass with Java 21 on Linux.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
