### PR TITLE
Remove unused file and CSS selectors

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/ClickHandler.js
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/ClickHandler.js
@@ -1,8 +1,0 @@
-Behaviour.register({
-  "INPUT.select-all" : function(e) {
-    e.onclick = function () {
-      e.focus();
-      e.select();
-    }
-  }
-});

--- a/src/main/webapp/css/design.css
+++ b/src/main/webapp/css/design.css
@@ -1,18 +1,8 @@
-INPUT {
-    border: none;
-    font-size: -2;
-}
-INPUT.select-all {
-    width:100%;
-    font-family: Console, "Courier New", Courier, monospace;
-}
-IMG#badge {
-    margin-left:2em;
-}
 h2 {
     margin-bottom: 1px;
     margin-top: 1em;
 }
+
 h3.help-format {
     border-bottom: 1px solid grey;
     margin-bottom: 1px;


### PR DESCRIPTION
`ClickHandler.js` is no longer used/nor loaded anywhere, nor are the related CSS selectors. Was previously used in https://github.com/jenkinsci/embeddable-build-status-plugin/pull/169 but the method of copying URLs was replaced in https://github.com/jenkinsci/embeddable-build-status-plugin/pull/222.

### Testing done

* Plugin works as before

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
