### PR TITLE
Replace <b> tags with <strong>, stop using color in text

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can override the color using the following valid color values:
 - any valid [SVG color name](https://www.december.com/html/spec/colorsvg.html)
 
 ## `job`
-**Note: This parameters is only supported for the unprotected URL!**
+**Note: This parameter is only supported for the unprotected URL!**
 
 The path for the selected job **or**
 any selector implemented via `JobSelectorExtensionPoint`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The customized examples above uses the following query parameters:
 
 You can override the color using the following valid color values:
 - one of the values: `red`, `brightgreen`, `green`, `yellowgreen`, `yellow`, `orange`, `lightgrey`, `blue`
-- a valid hexadecimal HTML RGB color <b>without</b> the hashtag (e.g. `FFAABB`).
+- a valid hexadecimal HTML RGB color <strong>without</strong> the hashtag (e.g. `FFAABB`).
 - any valid [SVG color name](https://www.december.com/html/spec/colorsvg.html)
 
 ## `job`
@@ -75,12 +75,12 @@ If you omit this parameter you can customize any "untethered" badge you like.
 **Important**
 
 The job selector string **must** be URL escaped. \
-If you are using <b>Multibranch Pipelines</b> the <b>branch</b> within the selector needs to be URL encoded <b style="color: red">twice</b>.
+If you are using <strong>Multibranch Pipelines</strong> the <strong>branch</strong> within the selector needs to be URL encoded <strong>twice</strong>.
 
 *Example* \
-<code>?job=<span style="color: blue">path/to/job</span>/branch/path</code> <b style="color: red">&#10060;</b> \
+<code>?job=path/to/job/branch/path</code> <strong>&#10060;</strong> \
 would become\
-<code>?job=<span style="color: blue">path%2Fto%2Fjob</span>%2Fbranch<b style="color: red">%252F</b>path</code> <b style="color: green">&#10004;</b>
+<code>?job=path%2Fto%2Fjob%2Fbranch<strong>%252F</strong>path</code> <strong>&#10004;</strong>
 
 ##### *ExtensionPoint* 
 This plugin provides a [`JobSelectorExtensionPoint`](https://www.jenkins.io/doc/developer/extensions/embeddable-build-status/#jobselectorextensionpoint) which allow for custom job selector implementations.
@@ -122,7 +122,7 @@ All those selectors can be concatenated as comma separated list:
 
 This searches in the last `10` runs for the first successful build of the `master` branch (provided the Build Parameter `BRANCH` exists).
 
-**Note:** If you are using <b>Multibranch Pipelines</b> the <b>branch name</b> within the selector needs to be URL encoded <b style="color: red">twice</b> (see [job](#job) for further information).
+**Note:** If you are using <strong>Multibranch Pipelines</strong> the <strong>branch name</strong> within the selector needs to be URL encoded twice (see [job](#job) for further information).
 
 ## `link`
 Provide a link to be opened on clicking on the badge.

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.jelly
@@ -54,12 +54,12 @@
 
       <h3 class="help-format">${%Plain link}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${badgeUrl}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${badgeUrl}"/>
         <br/>
         ${badgeUrl}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${publicBadge}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${publicBadge}"/>
         <br/>
         ${publicBadge}
       </p>
@@ -69,12 +69,12 @@
 
       <h3 class="help-format">${%Markdown}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${markdownProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${markdownProtectedLink}"/>
         <br/>
         ${markdownProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${markdownUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${markdownUnprotectedLink}"/>
         <br/>
         ${markdownUnprotectedLink}
       </p>
@@ -84,12 +84,12 @@
 
       <h3 class="help-format">${%HTML}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${htmlProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${htmlProtectedLink}"/>
         <br/>
         ${htmlProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${htmlUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${htmlUnprotectedLink}"/>
         <br/>
         ${htmlUnprotectedLink}
       </p>
@@ -99,12 +99,12 @@
 
       <h3 class="help-format">${%Asciidoc}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${asciidocProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${asciidocProtectedLink}"/>
         <br/>
         ${asciidocProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${asciidocUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${asciidocUnprotectedLink}"/>
         <br/>
         ${asciidocUnprotectedLink}
       </p>
@@ -114,12 +114,12 @@
 
       <h3 class="help-format">${%Confluence}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${confluenceProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${confluenceProtectedLink}"/>
         <br/>
         ${confluenceProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${confluenceUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${confluenceUnprotectedLink}"/>
         <br/>
         ${confluenceUnprotectedLink}
       </p>
@@ -129,12 +129,12 @@
 
       <h3 class="help-format">${%XWiki}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${xwikiProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${xwikiProtectedLink}"/>
         <br/>
         ${xwikiProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${xwikiUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${xwikiUnprotectedLink}"/>
         <br/>
         ${xwikiUnprotectedLink}
       </p>
@@ -144,12 +144,12 @@
 
       <h3 class="help-format">${%RDoc}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${rdocProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${rdocProtectedLink}"/>
         <br/>
         ${rdocProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${rdocUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${rdocUnprotectedLink}"/>
         <br/>
         ${rdocUnprotectedLink}
       </p>
@@ -159,12 +159,12 @@
 
       <h3 class="help-format">${%Textile}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${textileProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${textileProtectedLink}"/>
         <br/>
         ${textileProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${textileUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${textileUnprotectedLink}"/>
         <br/>
         ${textileUnprotectedLink}
       </p>
@@ -174,12 +174,12 @@
 
       <h3 class="help-format">${%Bitbucket}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${bitbucketProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${bitbucketProtectedLink}"/>
         <br/>
         ${bitbucketProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${bitbucketUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${bitbucketUnprotectedLink}"/>
         <br/>
         ${bitbucketUnprotectedLink}
       </p>
@@ -189,12 +189,12 @@
 
       <h3 class="help-format">${%Text Only}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${textUrl}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${textUrl}"/>
         <br/>
         ${textUrl}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${publicText}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${publicText}"/>
         <br/>
         ${publicText}
       </p>

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.properties
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/JobBadgeAction/index.properties
@@ -3,22 +3,22 @@ blurb=Jenkins exposes the current status of your build as an image in a fixed UR
       can see the current state of the build. \
       <br>For each variant there are two URLs available for inclusion: <br> \
       <ul>  \
-       <li><b>protected</b> exposes the badge to users having at least 'Read' permission on the job</li> \
-       <li><b>unprotected</b> exposes the badge to users having at least 'ViewStatus' permission on the job</li> \
+       <li><strong>protected</strong> exposes the badge to users having at least 'Read' permission on the job</li> \
+       <li><strong>unprotected</strong> exposes the badge to users having at least 'ViewStatus' permission on the job</li> \
       </ul> \
       If you want the status icons to be public readable/accessible, just grant the 'ViewStatus' permission globally to 'anonymous'. \
       <h2>Note</h2>\
-      If you are using <b>Multibranch Pipelines</b> the <b>branch</b> within the job path or name needs to be URL encoded <b style="color: red">twice</b>.<br/><br/> \
-      <b>Example:</b><br/> \
-      <code>?job=<span style="color: blue">path/to/job</span>/<b style="color: red">branch/path</b></code><br/> \
+      If you are using <strong>Multibranch Pipelines</strong> the <strong>branch</strong> within the job path or name needs to be URL encoded <strong>twice</strong>.<br/><br/> \
+      <strong>Example:</strong><br/> \
+      <code>?job=path/to/job/branch/path</code><br/> \
       would become<br/> \
-      <code>?job=<span style="color: blue">path%2Fto%2Fjob</span>%2F<b style="color: red">branch%252Fpath</b></code><br/><br/> \
-      <b>See examples below!</b> \
+      <code>?job=path%2Fto%2Fjob%2Fbranch%252Fpath</code><br/><br/> \
+      <strong>See examples below!</strong> \
       <h2>Configuration</h2> \
       Please read the <a href="https://plugins.jenkins.io/embeddable-build-status/">documentation</a> to configure and customize your badge.
 
 blurb_text=Jenkins also exposes the current status of your build in plain text. \
       You can use this in external scripts for easier interpretation of the current state of the build. \
-      Similar to the badge there are both <b>protected</b>, as well as <b>unprotected</b> variants.
+      Similar to the badge there are both <strong>protected</strong>, as well as <strong>unprotected</strong> variants.
 
 examples_note=(Hover badge to see custom configuration)

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.jelly
@@ -54,12 +54,12 @@
 
       <h3 class="help-format">${%Plain link}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${badgeUrl}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${badgeUrl}"/>
         <br/>
         ${badgeUrl}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${publicBadge}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${publicBadge}"/>
         <br/>
         ${publicBadge}
       </p>
@@ -69,12 +69,12 @@
 
       <h3 class="help-format">${%Markdown}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${markdownProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${markdownProtectedLink}"/>
         <br/>
         ${markdownProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${markdownUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${markdownUnprotectedLink}"/>
         <br/>
         ${markdownUnprotectedLink}
       </p>
@@ -84,12 +84,12 @@
 
       <h3 class="help-format">${%HTML}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${htmlProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${htmlProtectedLink}"/>
         <br/>
         ${htmlProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${htmlUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${htmlUnprotectedLink}"/>
         <br/>
         ${htmlUnprotectedLink}
       </p>
@@ -99,12 +99,12 @@
 
       <h3 class="help-format">${%Asciidoc}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${asciidocProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${asciidocProtectedLink}"/>
         <br/>
         ${asciidocProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${asciidocUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${asciidocUnprotectedLink}"/>
         <br/>
         ${asciidocUnprotectedLink}
       </p>
@@ -114,12 +114,12 @@
 
       <h3 class="help-format">${%Confluence}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${confluenceProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${confluenceProtectedLink}"/>
         <br/>
         ${confluenceProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${confluenceUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${confluenceUnprotectedLink}"/>
         <br/>
         ${confluenceUnprotectedLink}
       </p>
@@ -129,12 +129,12 @@
 
       <h3 class="help-format">${%XWiki}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${xwikiProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${xwikiProtectedLink}"/>
         <br/>
         ${xwikiProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${xwikiUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${xwikiUnprotectedLink}"/>
         <br/>
         ${xwikiUnprotectedLink}
       </p>
@@ -144,12 +144,12 @@
 
       <h3 class="help-format">${%RDoc}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${rdocProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${rdocProtectedLink}"/>
         <br/>
         ${rdocProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${rdocUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${rdocUnprotectedLink}"/>
         <br/>
         ${rdocUnprotectedLink}
       </p>
@@ -159,12 +159,12 @@
 
       <h3 class="help-format">${%Textile}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${textileProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${textileProtectedLink}"/>
         <br/>
         ${textileProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${textileUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${textileUnprotectedLink}"/>
         <br/>
         ${textileUnprotectedLink}
       </p>
@@ -174,12 +174,12 @@
 
       <h3 class="help-format">${%Bitbucket}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${bitbucketProtectedLink}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${bitbucketProtectedLink}"/>
         <br/>
         ${bitbucketProtectedLink}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${bitbucketUnprotectedLink}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${bitbucketUnprotectedLink}"/>
         <br/>
         ${bitbucketUnprotectedLink}
       </p>
@@ -189,12 +189,12 @@
 
       <h3 class="help-format">${%Text Only}</h3>
       <p>
-        <b>${%Protected}</b> <l:copyButton text="${textUrl}"/>
+        <strong>${%Protected}</strong> <l:copyButton text="${textUrl}"/>
         <br/>
         ${textUrl}
       </p>
       <p>
-        <b>${%Unprotected}</b> <l:copyButton text="${publicText}"/>
+        <strong>${%Unprotected}</strong> <l:copyButton text="${publicText}"/>
         <br/>
         ${publicText}
       </p>

--- a/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.properties
+++ b/src/main/resources/org/jenkinsci/plugins/badge/actions/RunBadgeAction/index.properties
@@ -3,22 +3,22 @@ blurb=Jenkins exposes the current status of your build as an image in a fixed UR
       can see the current state of the build. \
       <br>For each variant there are two URLs available for inclusion: <br> \
       <ul>  \
-       <li><b>protected</b> exposes the badge to users having at least 'Read' permission on the job</li> \
-       <li><b>unprotected</b> exposes the badge to users having at least 'ViewStatus' permission on the job</li> \
+       <li><strong>protected</strong> exposes the badge to users having at least 'Read' permission on the job</li> \
+       <li><strong>unprotected</strong> exposes the badge to users having at least 'ViewStatus' permission on the job</li> \
       </ul> \
       If you want the status icons to be public readable/accessible, just grant the 'ViewStatus' permission globally to 'anonymous'. \
       <h2>Note</h2>\
-      If you are using <b>Multibranch Pipelines</b> the <b>branch</b> within the job path or name needs to be URL encoded <b style="color: red">twice</b>.<br/><br/> \
-      <b>Example:</b><br/> \
-      <code>?job=<span style="color: blue">path/to/job</span>/<b style="color: red">branch/path</b></code><br/> \
+      If you are using <strong>Multibranch Pipelines</strong> the <strong>branch</strong> within the job path or name needs to be URL encoded <strong>twice</strong>.<br/><br/> \
+      <strong>Example:</strong><br/> \
+      <code>?job=path/to/job/branch/path</code><br/> \
       would become<br/> \
-      <code>?job=<span style="color: blue">path%2Fto%2Fjob</span>%2F<b style="color: red">branch%252Fpath</b></code><br/><br/> \
-      <b>See examples below!</b> \
+      <code>?job=path%2Fto%2Fjob%2Fbranch%252Fpath</code><br/><br/> \
+      <strong>See examples below!</strong> \
       <h2>Configuration</h2> \
       Please read the <a href="https://plugins.jenkins.io/embeddable-build-status/">documentation</a> to configure and customize your badge.
 
 blurb_text=Jenkins also exposes the current status of your build in plain text. \
       You can use this in external scripts for easier interpretation of the current state of the build. \
-      Similar to the badge there are both <b>protected</b>, as well as <b>unprotected</b> variants.
+      Similar to the badge there are both <strong>protected</strong>, as well as <strong>unprotected</strong> variants.
 
 examples_note=(Hover badge to see custom configuration)


### PR DESCRIPTION
## Replace `<b>` tags with `<strong>`, stop using color in text

- Minor grammar fix
- Replace <b> tags with <strong>, stop using color in text

### Testing done

Checked that rendering of the HTML pages looks as expected in both light and dark themes.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
