### PR TITLE
Use spotbugs plugin 4.8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,9 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.version>2.401.3</jenkins.version>
+    <!-- TODO: Remove when plugin pom is using this version or newer -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -5,6 +5,15 @@
     false positives.
   -->
   <Match>
+    <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    <Or>
+      <Class name="org.jenkinsci.plugins.badge.JobBadgeActionFactory" />     
+      <Class name="org.jenkinsci.plugins.badge.RunBadgeActionFactory" />
+      <Class name="org.jenkinsci.plugins.badge.StatusImage" />
+      <Class name="org.jenkinsci.plugins.badge.actions.PublicBuildStatusAction" />
+    </Or>
+  </Match>
+  <Match>
     <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
     <Or>
       <Class name="org.jenkinsci.plugins.badge.EmbeddableBadgeConfig" />


### PR DESCRIPTION
Includes suppressions of the CT_CONSTRUCTOR_THROW warning because Jenkins plugins are not generally vulnerable to a Finalizer attack.
