### PR TITLE
Omit spotbugs CT_CONSTRUCTOR_THROWS visitor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
     <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
+    <!-- TODO: Remove when plugin pom includes this omitVisitors -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef</spotbugs.omitVisitors>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -5,15 +5,6 @@
     false positives.
   -->
   <Match>
-    <Bug pattern="CT_CONSTRUCTOR_THROW" />
-    <Or>
-      <Class name="org.jenkinsci.plugins.badge.JobBadgeActionFactory" />     
-      <Class name="org.jenkinsci.plugins.badge.RunBadgeActionFactory" />
-      <Class name="org.jenkinsci.plugins.badge.StatusImage" />
-      <Class name="org.jenkinsci.plugins.badge.actions.PublicBuildStatusAction" />
-    </Or>
-  </Match>
-  <Match>
     <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
     <Or>
       <Class name="org.jenkinsci.plugins.badge.EmbeddableBadgeConfig" />


### PR DESCRIPTION
From https://github.com/jenkinsci/plugin-pom/pull/869#issuecomment-1860918407

> Discussion in spotbugs/spotbugs#2695
> https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions
> seems to relate to libraries used with SecurityManager which is dead
> and certainly does not apply to Jenkins; we do not expect untrusted code
> to be running inside the controller JVM, and it does not seem plausible
> that finalizer abuse would happen by accident.
