### PR TITLE
Add online help for addEmbeddableBadgeConfig Pipeline step

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-animatedOverlayColor.html
+++ b/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-animatedOverlayColor.html
@@ -1,0 +1,7 @@
+You can override the color using the following valid color values:
+
+<ul>
+	<li>one of the values: red, brightgreen, green, yellowgreen, yellow, orange, lightgrey, blue</li>
+	<li>a valid hexadecimal HTML RGB color without the hashtag (e.g. FFAABB).</li>
+	<li>any valid <a href="https://www.december.com/html/spec/colorsvg.html">SVG color name</a></li>
+</ul>

--- a/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-color.html
+++ b/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-color.html
@@ -1,0 +1,7 @@
+You can override the color using the following valid color values:
+
+<ul>
+	<li>one of the values: red, brightgreen, green, yellowgreen, yellow, orange, lightgrey, blue</li>
+	<li>a valid hexadecimal HTML RGB color without the hashtag (e.g. FFAABB).</li>
+	<li>any valid <a href="https://www.december.com/html/spec/colorsvg.html">SVG color name</a></li>
+</ul>

--- a/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-id.html
+++ b/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-id.html
@@ -1,0 +1,3 @@
+The identifier that will be assigned to this embeddable build status configuration.
+The identifier is passed as the value of <code>config</code> in the embeddable build status URL parameter.
+For example, if the identifier value was <code>win32build</code> then the URL parameter would be <code>config=win32build</code>.

--- a/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-link.html
+++ b/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-link.html
@@ -1,0 +1,1 @@
+The link that will be opened when the embeddable build status badge is clicked.

--- a/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-status.html
+++ b/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-status.html
@@ -1,0 +1,1 @@
+Text that describes the build status, usually the result of the build.

--- a/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-subject.html
+++ b/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help-subject.html
@@ -1,0 +1,2 @@
+The text placed on the left side of the embeddable build status.
+The subject is "build" by default.

--- a/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStep/help.html
@@ -1,0 +1,8 @@
+<p>
+Additional embeddable build status configurations can be created for a Jenkins Pipeline.
+Those embeddable build status configurations can be displayed in the same locations as the default embeddable build status configuration.
+For example, if a Pipeline defined a build status configuration named <code>win32build</code>, that configuration can be accessed by appending <code>config=win32build</code> as one of the embeddable build status URL parameters.
+</p>
+<p>
+Refer to the <a href="https://plugins.jenkins.io/embeddable-build-status/#plugin-content-pipeline-dsl">Embeddable build status</a> documentation for more details.
+</p>


### PR DESCRIPTION
## Add online help for addEmbeddableBadgeConfig Pipeline step

Online help text is copied from the help page of the plugin.

### Testing done

Confirmed that the new online help text is visible in the Pipeline help page of the running Jenkins instance.

No automated tests created.  If additional time is available, it is more valuable to provide broader examples or more interesting samples.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
