### PR TITLE
Implement extension for code coverage badges

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
   <dependencies>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>coverage</artifactId>
+      <version>1.7.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>ionicons-api</artifactId>
     </dependency>
     <dependency>
@@ -79,6 +85,21 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/org/jenkinsci/plugins/badge/extensions/CoverageParameterResolverExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/extensions/CoverageParameterResolverExtension.java
@@ -1,0 +1,91 @@
+package org.jenkinsci.plugins.badge.extensions;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.Value;
+import hudson.Extension;
+import hudson.model.Actionable;
+import hudson.model.Job;
+import hudson.model.Run;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.jenkins.plugins.coverage.metrics.model.ElementFormatter;
+import io.jenkins.plugins.coverage.metrics.steps.CoverageBuildAction;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.badge.extensionpoints.ParameterResolverExtensionPoint;
+
+@Extension(optional = true)
+public class CoverageParameterResolverExtension implements ParameterResolverExtensionPoint {
+
+    private static final ElementFormatter FORMATTER = new ElementFormatter();
+
+    public static final Logger LOGGER = Logger.getLogger(CoverageParameterResolverExtension.class.getName());
+
+    @Override
+    public String resolve(Actionable actionable, String parameter) {
+
+        // Just return parameter if coverage plugin is not installed
+        if (Jenkins.get().getPlugin("coverage") == null) {
+            return parameter;
+        }
+
+        if (parameter != null) {
+            if (actionable instanceof Run<?, ?>) {
+                Run<?, ?> run = (Run<?, ?>) actionable;
+
+                // Get the action
+                CoverageBuildAction action = run.getAction(CoverageBuildAction.class);
+                if (action == null) {
+                    return parameter;
+                }
+
+                // Get the values
+                Value intructionCoverage = action.getStatistics()
+                        .getValue(Baseline.PROJECT, Metric.INSTRUCTION)
+                        .orElse(null);
+                Value branchCoverage = action.getStatistics()
+                        .getValue(Baseline.PROJECT, Metric.BRANCH)
+                        .orElse(null);
+                Value lineOfCode = action.getStatistics()
+                        .getValue(Baseline.PROJECT, Metric.LOC)
+                        .orElse(null);
+
+                // Replace the parameters
+                parameter = parameter
+                        .replace(
+                                "intructionCoverage",
+                                intructionCoverage != null ? FORMATTER.format(intructionCoverage) : parameter)
+                        .replace(
+                                "branchCoverage", branchCoverage != null ? FORMATTER.format(branchCoverage) : parameter)
+                        .replace("lineOfCode", lineOfCode != null ? FORMATTER.format(lineOfCode) : parameter)
+                        .replace("colorInstructionCoverage", getColor(intructionCoverage))
+                        .replace("colorBranchCoverage", getColor(branchCoverage));
+
+            } else if (actionable instanceof Job<?, ?>) {
+                parameter = resolve(((Job<?, ?>) actionable).getLastBuild(), parameter);
+            }
+        }
+        return parameter;
+    }
+
+    private String getColor(Value value) {
+        if (value instanceof Coverage) {
+            Coverage coverage = (Coverage) value;
+            int percentage = coverage.getCoveredPercentage().toInt();
+            if (percentage <= 20.0) {
+                return "red";
+            } else if (percentage <= 30.0) {
+                return "orange";
+            } else if (percentage <= 40.0) {
+                return "yellow";
+            } else if (percentage <= 50.0) {
+                return "yellowgreen";
+            } else if (percentage <= 70.0) {
+                return "green";
+            } else {
+                return "brightgreen";
+            }
+        }
+        return "green";
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/badge/CoverageParameterResolverExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/CoverageParameterResolverExtensionTest.java
@@ -1,0 +1,40 @@
+package org.jenkinsci.plugins.badge;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.badge.extensions.CoverageParameterResolverExtension;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class CoverageParameterResolverExtensionTest {
+
+    @Test
+    void shouldResolveIntructionCoverage(JenkinsRule jenkins) throws Exception {
+        String pipeline = IOUtils.toString(
+                CoverageParameterResolverExtensionTest.class.getResourceAsStream("/pipelines/coverage.groovy"),
+                StandardCharsets.UTF_8);
+        WorkflowJob workflowJob = jenkins.createProject(WorkflowJob.class);
+        workflowJob.setDefinition(new CpsFlowDefinition(pipeline, false));
+        WorkflowRun run1 = workflowJob.scheduleBuild2(0).waitForStart();
+        jenkins.waitForCompletion(run1);
+        assertThat(run1.getResult(), equalTo(hudson.model.Result.SUCCESS));
+
+        // Coverages badges
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "unknown"), is("unknown"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "intructionCoverage"), is("50.00%"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "branchCoverage"), is("100.00%"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "lineOfCode"), is("10"));
+        assertThat(
+                new CoverageParameterResolverExtension().resolve(run1, "colorInstructionCoverage"), is("yellowgreen"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "colorBranchCoverage"), is("brightgreen"));
+    }
+}

--- a/src/test/resources/pipelines/coverage.groovy
+++ b/src/test/resources/pipelines/coverage.groovy
@@ -1,0 +1,36 @@
+pipeline {
+    agent any
+    stages {
+        stage('Generate Jacoco XML') {
+            steps {
+                script {
+                    def jacocoXmlContent = '''<?xml version="1.0" encoding="UTF-8"?>
+<report name="Example">
+    <sessioninfo id="session1" start="2023-01-01T12:00:00" dump="2023-01-01T12:30:00" />
+    <group name="Group1">
+        <package name="com.example.package">
+            <class name="com.example.package.ExampleClass" sourcefilename="ExampleClass.java">
+                <method name="exampleMethod" desc="()V" line="10">
+                    <counter type="INSTRUCTION" missed="50" covered="50" />
+                    <counter type="BRANCH" missed="0" covered="50" />
+                    <counter type="LINE" missed="5" covered="5" />
+                    <counter type="COMPLEXITY" missed="5" covered="5" />
+                    <counter type="METHOD" missed="1" covered="1" />
+                    <counter type="CLASS" missed="0" covered="1" />
+                </method>
+            </class>
+        </package>
+    </group>
+</report>
+                    '''
+                    writeFile(file: 'jacoco.xml', text: jacocoXmlContent, encoding: 'UTF-8')
+                }
+            }
+        }
+        stage('Record Test and coverage') {
+            steps {
+                recordCoverage(tools: [[parser: 'JACOCO']])
+            }
+        }
+    }
+}


### PR DESCRIPTION
Can be a plugin if not integration to core plugin.

See https://community.jenkins.io/t/how-to-use-embeddable-build-status-plugin-to-display-code-coverage/11463/3

- Missing some test
- Perhaps other metrics can be added in the future
- Missing documentation

### Testing done

Automated tests and interactive

![coverage](https://github.com/jenkinsci/embeddable-build-status-plugin/assets/825750/7f013f59-468e-49cb-90f4-f523adf7f5d6)


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
