### PR TITLE
[JENKINS-70464] Test `BuildParameterResolverExtensionTest` 

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtensionTest.java
@@ -1,0 +1,109 @@
+package org.jenkinsci.plugins.badge.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class BuildParameterResolverExtensionTest {
+
+    @Mock
+    private Run<?, ?> runMock;
+
+    @Mock
+    private ParametersAction paramsMock;
+
+    private BuildParameterResolverExtension resolver;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        resolver = new BuildParameterResolverExtension();
+    }
+
+    // A custom class to control the toString() behavior
+    private static class CustomObject {
+        @Override
+        public String toString() {
+            return "default";
+        }
+    }
+    @Test
+    void resolveShouldReturnOriginalParameterIfRunIsNull() {
+        String parameter = "params.paramName";
+        assertEquals(parameter, resolver.resolve(null, parameter));
+    }
+
+    @Test
+    void resolveShouldReturnOriginalParameterIfNoParametersAction() {
+        String parameter = "params.paramName";
+        when(runMock.getAction(ParametersAction.class)).thenReturn(null);
+
+        assertEquals(parameter, resolver.resolve(runMock, parameter));
+    }
+
+    @Test
+    void resolveShouldReplaceParameterWithParamValue() {
+        String paramName = "paramName";
+        String parameter = "params." + paramName;
+        String paramValue = "paramValue";
+
+        ParameterValue valueMock = mock(ParameterValue.class);
+        when(valueMock.getValue()).thenReturn(paramValue);
+
+        when(paramsMock.getParameter(paramName)).thenReturn(valueMock);
+        when(runMock.getAction(ParametersAction.class)).thenReturn(paramsMock);
+
+        assertEquals(paramValue, resolver.resolve(runMock, parameter));
+    }
+
+    @Test
+    void resolveShouldReplaceParameterWithDefaultValueIfParamNotFound() {
+        String paramName = "paramName";
+        String defaultValue = "default";
+        String parameter = "params." + paramName + "|" + defaultValue;
+
+        when(paramsMock.getParameter(paramName)).thenReturn(null);
+        when(runMock.getAction(ParametersAction.class)).thenReturn(paramsMock);
+
+        assertEquals(defaultValue, resolver.resolve(runMock, parameter));
+    }
+
+    @Test
+    void resolveShouldReplaceParameterWithDefaultValueIfParamValueIsNull() {
+        String paramName = "paramName";
+        String defaultValue = "default";
+        String parameter = "params." + paramName + "|" + defaultValue;
+
+        ParameterValue valueMock = mock(ParameterValue.class);
+        when(valueMock.getValue()).thenReturn(null);
+
+        when(paramsMock.getParameter(paramName)).thenReturn(valueMock);
+        when(runMock.getAction(ParametersAction.class)).thenReturn(paramsMock);
+
+        assertEquals(defaultValue, resolver.resolve(runMock, parameter));
+    }
+
+    @Test
+    void resolveShouldReplaceParameterWithDefaultValueIfParamValueToStringIsNull() {
+        String paramName = "paramName";
+        String defaultValue = "default";
+        String parameter = "params." + paramName + "|" + defaultValue;
+
+        ParameterValue valueMock = mock(ParameterValue.class);
+        when(valueMock.getValue()).thenReturn(new CustomObject()); // Replace CustomObject with your own class
+
+        when(paramsMock.getParameter(paramName)).thenReturn(valueMock);
+        when(runMock.getAction(ParametersAction.class)).thenReturn(paramsMock);
+
+        assertEquals(defaultValue, resolver.resolve(runMock, parameter));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtensionTest.java
@@ -35,6 +35,7 @@ public class BuildParameterResolverExtensionTest {
             return "default";
         }
     }
+
     @Test
     void resolveShouldReturnOriginalParameterIfRunIsNull() {
         String parameter = "params.paramName";
@@ -105,5 +106,4 @@ public class BuildParameterResolverExtensionTest {
 
         assertEquals(defaultValue, resolver.resolve(runMock, parameter));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtensionTest.java
@@ -99,7 +99,7 @@ public class BuildParameterResolverExtensionTest {
         String parameter = "params." + paramName + "|" + defaultValue;
 
         ParameterValue valueMock = mock(ParameterValue.class);
-        when(valueMock.getValue()).thenReturn(new CustomObject()); // Replace CustomObject with your own class
+        when(valueMock.getValue()).thenReturn(new CustomObject());
 
         when(paramsMock.getParameter(paramName)).thenReturn(valueMock);
         when(runMock.getAction(ParametersAction.class)).thenReturn(paramsMock);

--- a/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtensionTest.java
@@ -30,9 +30,15 @@ public class BuildParameterResolverExtensionTest {
 
     // A custom class to control the toString() behavior
     private static class CustomObject {
+        final String returnValue;
+
+        CustomObject(String returnValue) {
+            this.returnValue = returnValue;
+        }
+
         @Override
         public String toString() {
-            return "default";
+            return returnValue;
         }
     }
 
@@ -93,17 +99,18 @@ public class BuildParameterResolverExtensionTest {
     }
 
     @Test
-    void resolveShouldReplaceParameterWithDefaultValueIfParamValueToStringIsNull() {
+    void resolveShouldReplaceParameterWithCustomObjectValueIfParamValueToStringIsNull() {
         String paramName = "paramName";
         String defaultValue = "default";
         String parameter = "params." + paramName + "|" + defaultValue;
+        String customObjectReturnValue = defaultValue + "CustomObject";
 
         ParameterValue valueMock = mock(ParameterValue.class);
-        when(valueMock.getValue()).thenReturn(new CustomObject());
+        when(valueMock.getValue()).thenReturn(new CustomObject(customObjectReturnValue));
 
         when(paramsMock.getParameter(paramName)).thenReturn(valueMock);
         when(runMock.getAction(ParametersAction.class)).thenReturn(paramsMock);
 
-        assertEquals(defaultValue, resolver.resolve(runMock, parameter));
+        assertEquals(customObjectReturnValue, resolver.resolve(runMock, parameter));
     }
 }


### PR DESCRIPTION
In response to #114, 

### Testing done

- added `BuildParameterResolverExtensionTest.java`
- Test coverage shown below

![Screenshot 2024-01-26 161753](https://github.com/jenkinsci/embeddable-build-status-plugin/assets/14294846/ac34f054-5c81-44d8-a0aa-06a7d5dc7794)


<!-- Comment:


Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
