### PR TITLE
[JENKINS-70464] Improve `EmbeddableBadgeConfigsActionTest` test coverage

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/badge/actions/EmbeddableBadgeConfigsActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/actions/EmbeddableBadgeConfigsActionTest.java
@@ -1,33 +1,125 @@
 package org.jenkinsci.plugins.badge.actions;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.BeforeEach;
+import hudson.model.Run;
+import org.jenkinsci.plugins.badge.EmbeddableBadgeConfig;
 import org.junit.jupiter.api.Test;
 
-public class EmbeddableBadgeConfigsActionTest {
+class EmbeddableBadgeConfigsActionTest {
 
-    EmbeddableBadgeConfigsAction embeddableBadgeConfigsAction;
+    @Test
+    void testGetUrlName() {
+        // Given
+        EmbeddableBadgeConfigsAction action = new EmbeddableBadgeConfigsAction();
 
-    @BeforeEach
-    void setUp() {
-        embeddableBadgeConfigsAction = new EmbeddableBadgeConfigsAction();
+        // When
+        String urlName = action.getUrlName();
+
+        // Then
+        assertEquals("", urlName, "UrlName should be an empty string");
     }
 
     @Test
-    public void getUrlNameTest() {
-        assertThat(embeddableBadgeConfigsAction.getUrlName(), is(""));
+    void testGetDisplayName() {
+        // Given
+        EmbeddableBadgeConfigsAction action = new EmbeddableBadgeConfigsAction();
+
+        // When
+        String displayName = action.getDisplayName();
+
+        // Then
+        assertEquals("", displayName, "DisplayName should be an empty string");
     }
 
     @Test
-    public void getDisplayNameTest() {
-        assertThat(embeddableBadgeConfigsAction.getDisplayName(), is(""));
+    void testGetIconFileName() {
+        // Given
+        EmbeddableBadgeConfigsAction action = new EmbeddableBadgeConfigsAction();
+
+        // When
+        String iconFileName = action.getIconFileName();
+
+        // Then
+        assertNull(iconFileName, "IconFileName should be null");
     }
 
     @Test
-    public void getIconFileNameTest() {
-        assertThat(embeddableBadgeConfigsAction.getIconFileName(), is(nullValue()));
+    void testResolveWithValidId() {
+        // Given
+        Run<?, ?> run = mock(Run.class);
+        EmbeddableBadgeConfigsAction action = mock(EmbeddableBadgeConfigsAction.class);
+        when(run.getAction(EmbeddableBadgeConfigsAction.class)).thenReturn(action);
+        String id = "someId";
+        EmbeddableBadgeConfig expectedConfig = mock(EmbeddableBadgeConfig.class);
+        when(action.getConfig(id)).thenReturn(expectedConfig);
+
+        // When
+        EmbeddableBadgeConfig actualConfig = EmbeddableBadgeConfigsAction.resolve(run, id);
+
+        // Then
+        assertEquals(expectedConfig, actualConfig);
+    }
+
+    @Test
+    void testResolveWithNullId() {
+        // Given
+        Run<?, ?> run = mock(Run.class);
+
+        // When
+        EmbeddableBadgeConfig actualConfig = EmbeddableBadgeConfigsAction.resolve(run, null);
+
+        // Then
+        assertNull(actualConfig);
+    }
+
+    @Test
+    void testResolveWithNullAction() {
+        // Given
+        Run<?, ?> run = mock(Run.class);
+        when(run.getAction(EmbeddableBadgeConfigsAction.class)).thenReturn(null);
+        String id = "someId";
+
+        // When
+        EmbeddableBadgeConfig actualConfig = EmbeddableBadgeConfigsAction.resolve(run, id);
+
+        // Then
+        assertNull(actualConfig);
+    }
+
+    @Test
+    void testGetConfig() {
+        // Given
+        EmbeddableBadgeConfigsAction action = new EmbeddableBadgeConfigsAction();
+        EmbeddableBadgeConfig config = mock(EmbeddableBadgeConfig.class);
+        when(config.getID()).thenReturn("someId");
+        action.addConfig(config);
+
+        // When
+        EmbeddableBadgeConfig actualConfig = action.getConfig("someId");
+
+        // Then
+        assertNotNull(actualConfig, "Config should not be null");
+        assertEquals(config, actualConfig, "Config objects should be equal");
+        assertEquals("someId", actualConfig.getID(), "Config ID should match");
+    }
+
+    @Test
+    void testAddConfig() {
+        // Given
+        EmbeddableBadgeConfigsAction action = new EmbeddableBadgeConfigsAction();
+        EmbeddableBadgeConfig config = mock(EmbeddableBadgeConfig.class);
+        when(config.getID()).thenReturn("someId");
+
+        // When
+        action.addConfig(config);
+
+        // Then
+        EmbeddableBadgeConfig actualConfig = action.getConfig("someId");
+        assertNotNull(actualConfig, "Config should not be null");
+        assertEquals(config, actualConfig, "Config objects should be equal");
+        assertEquals("someId", actualConfig.getID(), "Config ID should match");
     }
 }


### PR DESCRIPTION
In response to #114, 

### Testing done

- Increased the test coverage of existing `EmbeddableBadgeConfigsActionTest.java`
- Improved test coverage shown below

![Screenshot 2024-01-26 161753](https://github.com/jenkinsci/embeddable-build-status-plugin/assets/14294846/5cb46f58-6e4d-4d12-8b03-ce2954df8644)


<!-- Comment:


Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
