### PR TITLE
[JENKINS-70464] Improve `AddEmbeddableBadgeConfigStepTest` test coverage

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/dsl/AddEmbeddableBadgeConfigStepTest.java
@@ -1,28 +1,64 @@
 package org.jenkinsci.plugins.badge.dsl;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import hudson.model.TaskListener;
+import org.junit.jupiter.api.Test;
 
-public class AddEmbeddableBadgeConfigStepTest {
+class AddEmbeddableBadgeConfigStepTest {
+
     @Test
-    public void testConstructor() {
-        AddEmbeddableBadgeConfigStep addEmbeddableBadgeConfigStep =
-                new AddEmbeddableBadgeConfigStep("test-Id-constructor");
-        assertThat(addEmbeddableBadgeConfigStep.getID(), is("test-Id-constructor"));
-        assertThat(addEmbeddableBadgeConfigStep.getSubject(), is(nullValue()));
-        assertThat(addEmbeddableBadgeConfigStep.getStatus(), is(nullValue()));
-        assertThat(addEmbeddableBadgeConfigStep.getColor(), is(nullValue()));
-        assertThat(addEmbeddableBadgeConfigStep.getAnimatedOverlayColor(), is(nullValue()));
-        assertThat(addEmbeddableBadgeConfigStep.getLink(), is(nullValue()));
+    void testConstructorAndGetID() {
+        AddEmbeddableBadgeConfigStep step = new AddEmbeddableBadgeConfigStep("testId");
+        assertEquals("testId", step.getID());
     }
 
     @Test
-    public void testGetAnimatedOverlayColor() {
-        AddEmbeddableBadgeConfigStep addEmbeddableBadgeConfigStep =
-                new AddEmbeddableBadgeConfigStep("test-animated-overlay-color");
-        assertThat(addEmbeddableBadgeConfigStep.getColor(), is(nullValue()));
+    void testGetSubjectAndSetSubject() {
+        AddEmbeddableBadgeConfigStep step = new AddEmbeddableBadgeConfigStep("testId");
+        assertNull(step.getSubject());
+        step.setSubject("testSubject");
+        assertEquals("testSubject", step.getSubject());
+    }
+
+    @Test
+    void testGetStatusAndSetStatus() {
+        AddEmbeddableBadgeConfigStep step = new AddEmbeddableBadgeConfigStep("testId");
+        assertNull(step.getStatus());
+        step.setStatus("testStatus");
+        assertEquals("testStatus", step.getStatus());
+    }
+
+    @Test
+    void testGetColorAndSetColor() {
+        AddEmbeddableBadgeConfigStep step = new AddEmbeddableBadgeConfigStep("testId");
+        assertNull(step.getColor());
+        step.setColor("testColor");
+        assertEquals("testColor", step.getColor());
+    }
+
+    @Test
+    void testGetAnimatedOverlayColorAndSetAnimatedOverlayColor() {
+        AddEmbeddableBadgeConfigStep step = new AddEmbeddableBadgeConfigStep("testId");
+        assertNull(step.getAnimatedOverlayColor());
+        step.setAnimatedOverlayColor("testOverlayColor");
+        assertEquals("testOverlayColor", step.getAnimatedOverlayColor());
+    }
+
+    @Test
+    void testGetLinkAndSetLink() {
+        AddEmbeddableBadgeConfigStep step = new AddEmbeddableBadgeConfigStep("testId");
+        assertNull(step.getLink());
+        step.setLink("testLink");
+        assertEquals("testLink", step.getLink());
+    }
+
+    @Test
+    void testDescriptor() {
+        AddEmbeddableBadgeConfigStep.DescriptorImpl descriptor = new AddEmbeddableBadgeConfigStep.DescriptorImpl();
+        assertEquals("addEmbeddableBadgeConfiguration", descriptor.getFunctionName());
+        assertEquals("Add an Embeddable Badge Configuration", descriptor.getDisplayName());
+        assertEquals(1, descriptor.getRequiredContext().size());
+        assertTrue(descriptor.getRequiredContext().contains(TaskListener.class));
     }
 }


### PR DESCRIPTION
In response to #114 

### Testing done

- Increased the test coverage of existing `AddEmbeddableBadgeConfigStepTest.java`
- Improved test coverage shown below

![Screenshot 2024-01-30 013946](https://github.com/jenkinsci/embeddable-build-status-plugin/assets/14294846/fbd8bad6-e305-417c-9b45-2efaaff88024)


<!-- Comment:


Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
