### PR TITLE
Resolve incorrect badge examples when opened directly from URL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/actions/JobBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/JobBadgeAction.java
@@ -53,10 +53,12 @@ public class JobBadgeAction implements Action, IconSpec {
         /* Needed for the jelly syntax hints page */
         String url = "";
         StaplerRequest req = Stapler.getCurrentRequest();
-        if (req != null) {
-            url = req.getReferer();
-            if (url == null) {
-                url = "null-referer";
+        if (req != null && req.getRequestURL() != null) {
+            url = req.getRequestURL().toString();
+            int badgeIndex = url.lastIndexOf("badge/");
+
+            if (badgeIndex != -1) {
+                url = url.substring(0, badgeIndex);
             }
         }
         return url;

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/RunBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/RunBadgeAction.java
@@ -14,6 +14,7 @@ import org.jenkinsci.plugins.badge.*;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.WebMethod;
 
 public class RunBadgeAction implements Action, IconSpec {
@@ -48,8 +49,17 @@ public class RunBadgeAction implements Action, IconSpec {
     public String getUrl() {
         /* TODO: Is a permission check needed here? */
         /* Needed for the jelly syntax hints page */
-        String url = Stapler.getCurrentRequest().getReferer();
-        return url == null ? "null-referer" : url;
+        String url = "";
+        StaplerRequest req = Stapler.getCurrentRequest();
+        if (req != null && req.getRequestURL() != null) {
+            url = req.getRequestURL().toString();
+            int badgeIndex = url.lastIndexOf("badge/");
+
+            if (badgeIndex != -1) {
+                url = url.substring(0, badgeIndex);
+            }
+        }
+        return url;
     }
 
     public String getUrlEncodedFullName() {

--- a/src/test/java/org/jenkinsci/plugins/badge/actions/RunBadgeActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/actions/RunBadgeActionTest.java
@@ -37,13 +37,24 @@ class RunBadgeActionTest {
     }
 
     @Test
-    void getUrl() {
+    void getUrlWithoutBadge() {
         try (MockedStatic<Stapler> mockedStatic = Mockito.mockStatic(Stapler.class)) {
             StaplerRequest staplerRequest = Mockito.mock(StaplerRequest.class);
-            Mockito.when(staplerRequest.getReferer()).thenReturn("referer");
+            Mockito.when(staplerRequest.getRequestURL()).thenReturn(new StringBuffer("http://jenkins.io/"));
             mockedStatic.when(() -> Stapler.getCurrentRequest()).thenReturn(staplerRequest);
 
-            assertThat(runBadgeAction.getUrl(), is("referer"));
+            assertThat(runBadgeAction.getUrl(), is("http://jenkins.io/"));
+        }
+    }
+
+    @Test
+    void getUrlWithBadge() {
+        try (MockedStatic<Stapler> mockedStatic = Mockito.mockStatic(Stapler.class)) {
+            StaplerRequest staplerRequest = Mockito.mock(StaplerRequest.class);
+            Mockito.when(staplerRequest.getRequestURL()).thenReturn(new StringBuffer("http://jenkins.io/badge/"));
+            mockedStatic.when(() -> Stapler.getCurrentRequest()).thenReturn(staplerRequest);
+
+            assertThat(runBadgeAction.getUrl(), is("http://jenkins.io/"));
         }
     }
 


### PR DESCRIPTION
Closes #278 

### Approach:
Replaced the `getReferer()` method with `getRequestURL()` (I am not sure if it is the optimal way to do it, but it fixes the issue without any flaws). Also modified the test cases to use getRequestURL() with and without `badge/` at the end of the URL.

### Testing done

Before:
![before](https://github.com/jenkinsci/embeddable-build-status-plugin/assets/107404972/34d4b015-f281-460e-ac1d-b7c5af1aed57)

Now:


https://github.com/jenkinsci/embeddable-build-status-plugin/assets/107404972/76d047cb-1779-44c1-980a-95980c1c8175



```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
