### PR TITLE
Require Jenkins 2.479 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.2</version>
     <relativePath />
   </parent>
 
@@ -44,8 +44,10 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <!-- TODO Replace with the standard jenkins.baseline references after LTS requires Java 17  -->
+    <!-- <jenkins.version>${jenkins.baseline}.1</jenkins.version> -->
+    <jenkins.version>${jenkins.baseline}</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/java/org/jenkinsci/plugins/badge/EmbeddableBadgeConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/EmbeddableBadgeConfig.java
@@ -4,14 +4,18 @@
  */
 package org.jenkinsci.plugins.badge;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 public class EmbeddableBadgeConfig implements Serializable {
+    @Serial
     private static final long serialVersionUID = 1L;
+
     private final Map<String, String> colors = new HashMap<>() {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         {

--- a/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
@@ -5,10 +5,11 @@
  */
 package org.jenkinsci.plugins.badge;
 
-import static javax.servlet.http.HttpServletResponse.*;
+import static jakarta.servlet.http.HttpServletResponse.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.PluginWrapper;
+import jakarta.servlet.ServletException;
 import java.awt.Canvas;
 import java.awt.Font;
 import java.awt.FontFormatException;
@@ -23,13 +24,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * Status image as an {@link HttpResponse}, with proper cache handling.
@@ -242,7 +242,7 @@ class StatusImage implements HttpResponse {
     }
 
     @Override
-    public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node)
+    public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp, Object node)
             throws IOException, ServletException {
         String v = req.getHeader("If-None-Match");
         if (etag.equals(v)) {

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/EmbeddableBadgeConfigsAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/EmbeddableBadgeConfigsAction.java
@@ -8,6 +8,7 @@ import hudson.model.Action;
 import hudson.model.BuildBadgeAction;
 import hudson.model.Job;
 import hudson.model.Run;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +21,9 @@ import org.kohsuke.stapler.export.ExportedBean;
  */
 @ExportedBean(defaultVisibility = 2)
 public class EmbeddableBadgeConfigsAction implements Action, Serializable, BuildBadgeAction {
+    @Serial
     private static final long serialVersionUID = 1L;
+
     private Map<String, EmbeddableBadgeConfig> badgeConfigs = new HashMap<>();
 
     public EmbeddableBadgeConfigsAction() {}

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/JobBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/JobBadgeAction.java
@@ -15,7 +15,7 @@ import org.jenkinsci.plugins.badge.*;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.WebMethod;
 
 /**
@@ -52,7 +52,7 @@ public class JobBadgeAction implements Action, IconSpec {
     public String getUrl() {
         /* Needed for the jelly syntax hints page */
         String url = "";
-        StaplerRequest req = Stapler.getCurrentRequest();
+        StaplerRequest2 req = Stapler.getCurrentRequest2();
         if (req != null && req.getRequestURL() != null) {
             url = req.getRequestURL().toString();
             int badgeIndex = url.lastIndexOf("badge/");

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/PublicBuildStatusAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/PublicBuildStatusAction.java
@@ -25,8 +25,8 @@ import org.jenkinsci.plugins.badge.extensionpoints.JobSelectorExtensionPoint;
 import org.jenkinsci.plugins.badge.extensionpoints.RunSelectorExtensionPoint;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.WebMethod;
 
 /**
@@ -65,8 +65,8 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
 
     @WebMethod(name = "icon")
     public HttpResponse doIcon(
-            StaplerRequest req,
-            StaplerResponse rsp,
+            StaplerRequest2 req,
+            StaplerResponse2 rsp,
             @QueryParameter String job,
             @QueryParameter String build,
             @QueryParameter String style,
@@ -94,8 +94,8 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
 
     @WebMethod(name = "icon.svg")
     public HttpResponse doIconDotSvg(
-            StaplerRequest req,
-            StaplerResponse rsp,
+            StaplerRequest2 req,
+            StaplerResponse2 rsp,
             @QueryParameter String job,
             @QueryParameter String build,
             @QueryParameter String style,
@@ -109,7 +109,7 @@ public class PublicBuildStatusAction implements UnprotectedRootAction {
     }
 
     public String doText(
-            StaplerRequest req, StaplerResponse rsp, @QueryParameter String job, @QueryParameter String build) {
+            StaplerRequest2 req, StaplerResponse2 rsp, @QueryParameter String job, @QueryParameter String build) {
         if (job == null) {
             return "Missing query parameter: job";
         }

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/RunBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/RunBadgeAction.java
@@ -14,7 +14,7 @@ import org.jenkinsci.plugins.badge.*;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.WebMethod;
 
 public class RunBadgeAction implements Action, IconSpec {
@@ -50,7 +50,7 @@ public class RunBadgeAction implements Action, IconSpec {
         /* TODO: Is a permission check needed here? */
         /* Needed for the jelly syntax hints page */
         String url = "";
-        StaplerRequest req = Stapler.getCurrentRequest();
+        StaplerRequest2 req = Stapler.getCurrentRequest2();
         if (req != null && req.getRequestURL() != null) {
             url = req.getRequestURL().toString();
             int badgeIndex = url.lastIndexOf("badge/");

--- a/src/main/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/extensions/BuildParameterResolverExtension.java
@@ -21,8 +21,7 @@ public class BuildParameterResolverExtension implements ParameterResolverExtensi
 
     @Override
     public String resolve(Actionable actionable, String parameter) {
-        if (actionable instanceof Run) {
-            Run<?, ?> run = (Run<?, ?>) actionable;
+        if (actionable instanceof Run<?, ?> run) {
 
             ParametersAction params = run.getAction(ParametersAction.class);
             if (params != null) {
@@ -68,8 +67,8 @@ public class BuildParameterResolverExtension implements ParameterResolverExtensi
                     }
                 }
             }
-        } else if (actionable instanceof Job<?, ?>) {
-            parameter = resolve(((Job<?, ?>) actionable).getLastBuild(), parameter);
+        } else if (actionable instanceof Job<?, ?> job) {
+            parameter = resolve(job.getLastBuild(), parameter);
         }
         return parameter;
     }

--- a/src/main/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/extensions/SpecialValueParameterResolverExtension.java
@@ -17,8 +17,7 @@ public class SpecialValueParameterResolverExtension implements ParameterResolver
     @Override
     public String resolve(Actionable actionable, String parameter) {
         if (parameter != null) {
-            if (actionable instanceof Run<?, ?>) {
-                Run<?, ?> run = (Run<?, ?>) actionable;
+            if (actionable instanceof Run<?, ?> run) {
                 /* try to match any custom value:
                     ${buildId}
                     ${buildNumber}
@@ -36,8 +35,8 @@ public class SpecialValueParameterResolverExtension implements ParameterResolver
                         .replace("displayName", run.getDisplayName())
                         .replace("startTime", run.getTimestampString());
 
-            } else if (actionable instanceof Job<?, ?>) {
-                parameter = resolve(((Job<?, ?>) actionable).getLastBuild(), parameter);
+            } else if (actionable instanceof Job<?, ?> job) {
+                parameter = resolve(job.getLastBuild(), parameter);
             }
         }
         return parameter;

--- a/src/test/java/org/jenkinsci/plugins/badge/actions/RunBadgeActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/actions/RunBadgeActionTest.java
@@ -8,7 +8,7 @@ import hudson.model.Run;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -39,7 +39,7 @@ class RunBadgeActionTest {
     @Test
     void getUrlWithoutBadge() {
         try (MockedStatic<Stapler> mockedStatic = Mockito.mockStatic(Stapler.class)) {
-            StaplerRequest staplerRequest = Mockito.mock(StaplerRequest.class);
+            StaplerRequest2 staplerRequest = Mockito.mock(StaplerRequest2.class);
             Mockito.when(staplerRequest.getRequestURL()).thenReturn(new StringBuffer("http://jenkins.io/"));
             mockedStatic.when(() -> Stapler.getCurrentRequest()).thenReturn(staplerRequest);
 
@@ -50,7 +50,7 @@ class RunBadgeActionTest {
     @Test
     void getUrlWithBadge() {
         try (MockedStatic<Stapler> mockedStatic = Mockito.mockStatic(Stapler.class)) {
-            StaplerRequest staplerRequest = Mockito.mock(StaplerRequest.class);
+            StaplerRequest2 staplerRequest = Mockito.mock(StaplerRequest2.class);
             Mockito.when(staplerRequest.getRequestURL()).thenReturn(new StringBuffer("http://jenkins.io/badge/"));
             mockedStatic.when(() -> Stapler.getCurrentRequest()).thenReturn(staplerRequest);
 

--- a/src/test/java/org/jenkinsci/plugins/badge/actions/RunBadgeActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/actions/RunBadgeActionTest.java
@@ -41,7 +41,7 @@ class RunBadgeActionTest {
         try (MockedStatic<Stapler> mockedStatic = Mockito.mockStatic(Stapler.class)) {
             StaplerRequest2 staplerRequest = Mockito.mock(StaplerRequest2.class);
             Mockito.when(staplerRequest.getRequestURL()).thenReturn(new StringBuffer("http://jenkins.io/"));
-            mockedStatic.when(() -> Stapler.getCurrentRequest()).thenReturn(staplerRequest);
+            mockedStatic.when(() -> Stapler.getCurrentRequest2()).thenReturn(staplerRequest);
 
             assertThat(runBadgeAction.getUrl(), is("http://jenkins.io/"));
         }
@@ -52,7 +52,7 @@ class RunBadgeActionTest {
         try (MockedStatic<Stapler> mockedStatic = Mockito.mockStatic(Stapler.class)) {
             StaplerRequest2 staplerRequest = Mockito.mock(StaplerRequest2.class);
             Mockito.when(staplerRequest.getRequestURL()).thenReturn(new StringBuffer("http://jenkins.io/badge/"));
-            mockedStatic.when(() -> Stapler.getCurrentRequest()).thenReturn(staplerRequest);
+            mockedStatic.when(() -> Stapler.getCurrentRequest2()).thenReturn(staplerRequest);
 
             assertThat(runBadgeAction.getUrl(), is("http://jenkins.io/"));
         }


### PR DESCRIPTION
## Require Jenkins 2.479 or newer

Compile with Java 17 and Jakarta EE 9.

### Testing done

Confirmed that automated tests pass.  Confirmed that the [coverage badges extension plugin](https://plugins.jenkins.io/coverage-badges-extension/) compiles with Java 17 and Jakarta EE 9 and the incremental build of this plugin.  No changes were needed in the coverage badges extension plugin except in the pom.xml file.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
