### PR TITLE
[JENKINS-70464] Improve embeddable build status plugin test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.12</version>
+    <version>5.14</version>
     <relativePath />
   </parent>
 

--- a/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterRunSelectorExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterRunSelectorExtensionTest.java
@@ -1,12 +1,16 @@
 package org.jenkinsci.plugins.badge.extensions;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import hudson.model.Job;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
 import hudson.model.Result;
 import hudson.model.Run;
+import hudson.model.StringParameterValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -16,12 +20,14 @@ class BuildParameterRunSelectorExtensionTest {
     private BuildParameterRunSelectorExtension extension;
     private Job mockProject;
     private Run mockRun;
+    private ParametersAction mockParametersAction;
 
     @BeforeEach
     void setUp() {
         extension = new BuildParameterRunSelectorExtension();
         mockProject = Mockito.mock(Job.class);
         mockRun = Mockito.mock(Run.class);
+        mockParametersAction = Mockito.mock(ParametersAction.class);
     }
 
     @Test
@@ -133,5 +139,492 @@ class BuildParameterRunSelectorExtensionTest {
         when(mockRun.getResult()).thenReturn(Result.UNSTABLE);
         Run actualRun = extension.select(mockProject, "firstCompleted", null);
         assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldSelectLastBuildWithMatchingParameter() {
+        String paramName = "branch";
+        String paramValue = "master";
+        String rule = "params." + paramName + "=" + paramValue;
+        StringParameterValue stringParameterValue = new StringParameterValue(paramName, paramValue);
+
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+        when(mockRun.getAction(ParametersAction.class)).thenReturn(mockParametersAction);
+        when(mockParametersAction.getParameter(paramName)).thenReturn(stringParameterValue);
+
+        Run actualRun = extension.select(mockProject, "last:${" + rule + "}", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldContinueToNextBuildWithNonMatchingParameterValue() {
+        String paramName = "branch";
+        String paramValueRule = "master";
+        String paramValueActual = "develop";
+        String rule = "params." + paramName + "=" + paramValueRule;
+        StringParameterValue stringParameterValue = new StringParameterValue(paramName, paramValueActual);
+
+        Run mockRun2 = Mockito.mock(Run.class);
+        StringParameterValue matchingParameterValue = new StringParameterValue(paramName, paramValueRule);
+        ParametersAction mockParametersAction2 = Mockito.mock(ParametersAction.class);
+
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+        when(mockRun.getAction(ParametersAction.class)).thenReturn(mockParametersAction);
+        when(mockParametersAction.getParameter(paramName)).thenReturn(stringParameterValue);
+
+        // Set up the second run to match the parameter
+        when(mockRun.getPreviousBuild()).thenReturn(mockRun2);
+        when(mockRun2.getAction(ParametersAction.class)).thenReturn(mockParametersAction2);
+        when(mockParametersAction2.getParameter(paramName)).thenReturn(matchingParameterValue);
+
+        Run actualRun = extension.select(mockProject, "last:${" + rule + "}", null);
+        // It should have skipped the first run due to non-matching parameter
+        // and found the second run which does match
+        assertThat(actualRun, is(mockRun2));
+    }
+
+    @Test
+    void shouldHandleNullParameterValue() {
+        String paramName = "branch";
+        String paramValueRule = "master";
+        String rule = "params." + paramName + "=" + paramValueRule;
+        ParameterValue nullValueParameter = Mockito.mock(ParameterValue.class);
+
+        Run mockRun2 = Mockito.mock(Run.class);
+        StringParameterValue matchingParameterValue = new StringParameterValue(paramName, paramValueRule);
+        ParametersAction mockParametersAction2 = Mockito.mock(ParametersAction.class);
+
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+        when(mockRun.getAction(ParametersAction.class)).thenReturn(mockParametersAction);
+        when(mockParametersAction.getParameter(paramName)).thenReturn(nullValueParameter);
+        when(nullValueParameter.getValue()).thenReturn(null);
+
+        // Set up the second run to match the parameter
+        when(mockRun.getPreviousBuild()).thenReturn(mockRun2);
+        when(mockRun2.getAction(ParametersAction.class)).thenReturn(mockParametersAction2);
+        when(mockParametersAction2.getParameter(paramName)).thenReturn(matchingParameterValue);
+
+        Run actualRun = extension.select(mockProject, "last:${" + rule + "}", null);
+        assertThat(actualRun, is(mockRun2));
+    }
+
+    @Test
+    void shouldHandleMissingParameter() {
+        String paramName = "branch";
+        String paramValue = "master";
+        String rule = "params." + paramName + "=" + paramValue;
+
+        Run mockRun2 = Mockito.mock(Run.class);
+        StringParameterValue matchingParameterValue = new StringParameterValue(paramName, paramValue);
+        ParametersAction mockParametersAction2 = Mockito.mock(ParametersAction.class);
+
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+        when(mockRun.getAction(ParametersAction.class)).thenReturn(mockParametersAction);
+        when(mockParametersAction.getParameter(paramName)).thenReturn(null); // Parameter not found
+
+        // Set up the second run to match the parameter
+        when(mockRun.getPreviousBuild()).thenReturn(mockRun2);
+        when(mockRun2.getAction(ParametersAction.class)).thenReturn(mockParametersAction2);
+        when(mockParametersAction2.getParameter(paramName)).thenReturn(matchingParameterValue);
+
+        Run actualRun = extension.select(mockProject, "last:${" + rule + "}", null);
+        assertThat(actualRun, is(mockRun2));
+    }
+
+    @Test
+    void shouldHandleMissingParametersAction() {
+        String paramName = "branch";
+        String paramValue = "master";
+        String rule = "params." + paramName + "=" + paramValue;
+
+        Run mockRun2 = Mockito.mock(Run.class);
+        StringParameterValue matchingParameterValue = new StringParameterValue(paramName, paramValue);
+        ParametersAction mockParametersAction2 = Mockito.mock(ParametersAction.class);
+
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+        when(mockRun.getAction(ParametersAction.class)).thenReturn(null); // No ParametersAction
+
+        // Set up the second run to match the parameter
+        when(mockRun.getPreviousBuild()).thenReturn(mockRun2);
+        when(mockRun2.getAction(ParametersAction.class)).thenReturn(mockParametersAction2);
+        when(mockParametersAction2.getParameter(paramName)).thenReturn(matchingParameterValue);
+
+        Run actualRun = extension.select(mockProject, "last:${" + rule + "}", null);
+        assertThat(actualRun, is(mockRun2));
+    }
+
+    @Test
+    void shouldHandleInvalidRule() {
+        String invalidRule = "invalidRuleSyntax";
+
+        Run mockRun2 = Mockito.mock(Run.class);
+        // Create a valid parameter setup in the second run
+        String paramName = "branch";
+        String paramValue = "master";
+        StringParameterValue matchingParameterValue = new StringParameterValue(paramName, paramValue);
+        ParametersAction mockParametersAction2 = Mockito.mock(ParametersAction.class);
+
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+
+        // Set up the second run that would match if the rule was valid
+        when(mockRun.getPreviousBuild()).thenReturn(mockRun2);
+        when(mockRun2.getAction(ParametersAction.class)).thenReturn(mockParametersAction2);
+        when(mockParametersAction2.getParameter(paramName)).thenReturn(matchingParameterValue);
+
+        // For an invalid rule, all runs should be considered without parameter matching
+        Run actualRun = extension.select(mockProject, "last:" + invalidRule, null);
+        // We should get the first run because the invalid rule doesn't force parameter
+        // matching
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldReturnNullWhenNoMatchingBuilds() {
+        String paramName = "branch";
+        String paramValue = "master";
+        String rule = "params." + paramName + "=" + paramValue;
+
+        // Set up a chain of builds with no matching parameter
+        Run mockRun2 = Mockito.mock(Run.class);
+        ParametersAction mockParametersAction2 = Mockito.mock(ParametersAction.class);
+        StringParameterValue nonMatchingValue = new StringParameterValue(paramName, "develop");
+
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+        when(mockRun.getAction(ParametersAction.class)).thenReturn(mockParametersAction);
+        when(mockParametersAction.getParameter(paramName)).thenReturn(nonMatchingValue);
+
+        when(mockRun.getPreviousBuild()).thenReturn(mockRun2);
+        when(mockRun2.getAction(ParametersAction.class)).thenReturn(mockParametersAction2);
+        when(mockParametersAction2.getParameter(paramName)).thenReturn(nonMatchingValue);
+
+        // Last build in chain has no next build
+        when(mockRun2.getPreviousBuild()).thenReturn(null);
+
+        Run actualRun = extension.select(mockProject, "last:${" + rule + "}", null);
+        // No builds match so we should get null
+        assertThat(actualRun, is(nullValue()));
+    }
+
+    @Test
+    void shouldHandleRunWithNullResult() {
+        // For the "lastFailed" case, the implementation first checks
+        // job.getLastFailedBuild()
+        // So we need to mock this behavior
+        when(mockProject.getLastFailedBuild()).thenReturn(mockRun);
+
+        Run actualRun = extension.select(mockProject, "lastFailed", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleMultipleRuleMatchers() {
+        // Test cases for multiple rule matchers in a single runId
+        String paramName = "branch";
+        String paramValue = "master";
+        String rule = "params." + paramName + "=" + paramValue;
+
+        StringParameterValue stringParameterValue = new StringParameterValue(paramName, paramValue);
+
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+        when(mockRun.getAction(ParametersAction.class)).thenReturn(mockParametersAction);
+        when(mockParametersAction.getParameter(paramName)).thenReturn(stringParameterValue);
+
+        // Use multiple matchers in the runId
+        Run actualRun = extension.select(mockProject, "last:${" + rule + "}lastSuccessful", null);
+
+        // It should process both matchers and eventually select a run
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldContinueFindingSpecificRunWhenResultDoesNotMatch() {
+        Run mockRun2 = Mockito.mock(Run.class);
+        Run mockRun3 = Mockito.mock(Run.class);
+
+        when(mockProject.getFirstBuild()).thenReturn(mockRun);
+        when(mockRun.getNextBuild()).thenReturn(mockRun2);
+        when(mockRun2.getNextBuild()).thenReturn(mockRun3);
+        when(mockRun3.getNextBuild()).thenReturn(null);
+
+        // Use Result.FAILURE instead of mocking Result.isCompleteBuild
+        when(mockRun.getResult()).thenReturn(Result.FAILURE);
+
+        // Second run has Result that doesn't match
+        when(mockRun2.getResult()).thenReturn(Result.UNSTABLE);
+
+        // Third run has Result that matches
+        when(mockRun3.getResult()).thenReturn(Result.SUCCESS);
+
+        Run actualRun = extension.select(mockProject, "firstSuccessful", null);
+        // Should find mockRun3 as it matches SUCCESS
+        assertThat(actualRun, is(mockRun3));
+    }
+
+    @Test
+    void shouldProcessNonMatchingSpecific() {
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+
+        // Use known Result types instead of Boolean values
+        when(mockRun.getResult()).thenReturn(Result.SUCCESS);
+
+        // Test with a specific that doesn't match any of the known cases
+        Run actualRun = extension.select(mockProject, "lastUnknownState", null);
+
+        // It should still select the last build
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleInvalidParameterRule() {
+        // For an invalid parameter rule, we need to ensure it's actually in the ${}
+        // format
+        // but with invalid content inside that doesn't match params.x=y pattern
+        String invalidRule = "someInvalidContent";
+
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+        // The select method expects a proper runId format: "last:${rule}"
+        Run actualRun = extension.select(mockProject, "last", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleCompletedBuildCriteria() {
+        // For firstCompleted, we need to set up the lastCompletedBuild mock since
+        // that's what
+        // the actual implementation of BuildParameterRunSelectorExtension is using
+        when(mockProject.getLastCompletedBuild()).thenReturn(mockRun);
+        Run actualRun = extension.select(mockProject, "lastCompleted", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleNotMatchingSpecificTypeWithNullResult() {
+        // Test case where run.getResult() returns null in findSpecific method
+        Run mockRun2 = Mockito.mock(Run.class);
+
+        when(mockProject.getFirstBuild()).thenReturn(mockRun);
+        when(mockRun.getNextBuild()).thenReturn(mockRun2);
+        when(mockRun2.getNextBuild()).thenReturn(null);
+
+        // First run has null result
+        when(mockRun.getResult()).thenReturn(null);
+
+        // Second run has a result that matches
+        when(mockRun2.getResult()).thenReturn(Result.SUCCESS);
+
+        Run actualRun = extension.select(mockProject, "firstSuccessful", null);
+        assertThat(actualRun, is(mockRun2));
+    }
+
+    @Test
+    void shouldHandleMultipleSpecificTypeMatchers() {
+        // Test for each specific type in the switch cases
+        when(mockProject.getLastStableBuild()).thenReturn(mockRun);
+        Run actualRun = extension.select(mockProject, "lastStable", null);
+        assertThat(actualRun, is(mockRun));
+
+        // Reset with a new run for each type
+        Run mockRun2 = Mockito.mock(Run.class);
+        when(mockProject.getLastCompletedBuild()).thenReturn(mockRun2);
+        actualRun = extension.select(mockProject, "lastCompleted", null);
+        assertThat(actualRun, is(mockRun2));
+    }
+
+    @Test
+    void shouldHandleRuleMatchingWithAdditionalText() {
+        // Test case for matchRule with specific text and matcher
+        String paramName = "branch";
+        String paramValue = "master";
+        String rule = "params." + paramName + "=" + paramValue;
+        StringParameterValue stringParameterValue = new StringParameterValue(paramName, paramValue);
+
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+        when(mockRun.getAction(ParametersAction.class)).thenReturn(mockParametersAction);
+        when(mockParametersAction.getParameter(paramName)).thenReturn(stringParameterValue);
+
+        // Test with multiple matchers in the runId
+        Run actualRun = extension.select(mockProject, "last:${" + rule + "}additionalText", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleNullRunResult() {
+        Run mockRun2 = Mockito.mock(Run.class);
+
+        // Set up a chain with a null result that should skip to the next run
+        when(mockProject.getFirstBuild()).thenReturn(mockRun);
+        when(mockRun.getNextBuild()).thenReturn(mockRun2);
+        when(mockRun2.getNextBuild()).thenReturn(null);
+
+        // First run has a null result
+        when(mockRun.getResult()).thenReturn(null);
+
+        // Second run has a successful result
+        when(mockRun2.getResult()).thenReturn(Result.SUCCESS);
+
+        // Only the second run should satisfy our "firstSuccessful" condition
+        Run actualRun = extension.select(mockProject, "firstSuccessful", null);
+        assertThat(actualRun, is(mockRun2));
+    }
+
+    @Test
+    void shouldHandleForFirstCompletedSpecificCase() {
+        Run mockRun2 = Mockito.mock(Run.class);
+        Result mockResult = Mockito.mock(Result.class);
+
+        // Ensure the first run doesn't meet criteria
+        when(mockProject.getFirstBuild()).thenReturn(mockRun);
+        when(mockRun.getNextBuild()).thenReturn(mockRun2);
+        when(mockRun2.getNextBuild()).thenReturn(null);
+
+        // First run's result doesn't satisfy our conditions
+        when(mockRun.getResult()).thenReturn(Result.ABORTED);
+
+        // Second run has a completed result
+        when(mockRun2.getResult()).thenReturn(mockResult);
+        when(mockResult.isCompleteBuild()).thenReturn(true);
+
+        Run actualRun = extension.select(mockProject, "firstCompleted", null);
+        assertThat(actualRun, is(mockRun2));
+    }
+
+    @Test
+    void shouldHandleSpecificStableMatching() {
+        // Test specifically for the "Stable" condition branch
+        // For "lastStable", the implementation will use job.getLastStableBuild()
+        when(mockProject.getLastStableBuild()).thenReturn(mockRun);
+
+        Run actualRun = extension.select(mockProject, "lastStable", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleSpecificUnstableMatching() {
+        // Test specifically for the "Unstable" condition branch
+        // For "lastUnstable", the implementation will use job.getLastUnstableBuild()
+        when(mockProject.getLastUnstableBuild()).thenReturn(mockRun);
+
+        Run actualRun = extension.select(mockProject, "lastUnstable", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleSpecificUnsuccessfulMatching() {
+        // Test specifically for the "Unsuccessful" condition branch
+        // For "lastUnsuccessful", the implementation will use
+        // job.getLastUnsuccessfulBuild()
+        when(mockProject.getLastUnsuccessfulBuild()).thenReturn(mockRun);
+
+        Run actualRun = extension.select(mockProject, "lastUnsuccessful", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleRunWithPreviousRunProvided() {
+        // Test when a run is provided and we're looking for specific behavior
+        when(mockProject.getLastSuccessfulBuild()).thenReturn(mockRun);
+
+        Run actualRun = extension.select(mockProject, "lastSuccessful", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleEmptyRunId() {
+        // Test with an empty runId to ensure it doesn't match the regex pattern
+        Run actualRun = extension.select(mockProject, "", null);
+        assertThat(actualRun, is(nullValue()));
+    }
+
+    @Test
+    void shouldHandleDefaultCaseInSwitch() {
+        // Test the default case in the switch statement with an invalid specific value
+        Run actualRun = extension.select(mockProject, "lastInvalidSpecific", null);
+
+        // The method should try to get the last build as a fallback
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+        actualRun = extension.select(mockProject, "lastInvalidSpecific", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleNonMatchingParameterRule() {
+        // Test for a non-matching parameter pattern - focusing on matcher.find() branch
+        // For a non-parameter pattern, the rule doesn't match the format
+        // We need to mock the project's getLastBuild method to ensure we get a run
+        when(mockProject.getLastBuild()).thenReturn(mockRun);
+
+        // Use a real string that's in the format we need for the rule parameter
+        Run actualRun = extension.select(mockProject, "last", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldHandleComplexCombinationOfConditions() {
+        // Setup multiple runs with different conditions to exercise the complex logic
+        Run run1 = mockRun;
+        Run run2 = Mockito.mock(Run.class);
+        Run run3 = Mockito.mock(Run.class);
+
+        // Chain the runs
+        when(mockProject.getFirstBuild()).thenReturn(run1);
+        when(run1.getNextBuild()).thenReturn(run2);
+        when(run2.getNextBuild()).thenReturn(run3);
+        when(run3.getNextBuild()).thenReturn(null);
+
+        // Setup different results for each run
+        when(run1.getResult()).thenReturn(null); // No result
+        when(run2.getResult()).thenReturn(Result.UNSTABLE); // Unstable result
+        when(run3.getResult()).thenReturn(Result.SUCCESS); // Success result
+
+        // Test finding different specific types - but use the project.getLastXXX
+        // methods
+        when(mockProject.getLastUnstableBuild()).thenReturn(run2);
+        when(mockProject.getLastSuccessfulBuild()).thenReturn(run3);
+
+        Run actualRun = extension.select(mockProject, "lastUnstable", null);
+        assertThat(actualRun, is(run2));
+
+        actualRun = extension.select(mockProject, "lastSuccessful", null);
+        assertThat(actualRun, is(run3));
+    }
+
+    @Test
+    void shouldHandleRunWithSpecificConditions() {
+        // For lastUnstable, the implementation uses job.getLastUnstableBuild()
+        when(mockProject.getLastUnstableBuild()).thenReturn(mockRun);
+
+        Run actualRun = extension.select(mockProject, "lastUnstable", null);
+        assertThat(actualRun, is(mockRun));
+    }
+
+    @Test
+    void shouldMatchParameterValueWithSpecificPattern() {
+        // Test the parameter matching pattern
+        String paramName = "branch";
+        String paramValue = "master";
+
+        // Create a mock parameter
+        ParametersAction paramsAction = Mockito.mock(ParametersAction.class);
+        ParameterValue parameterValue = Mockito.mock(ParameterValue.class);
+
+        // Set up the mock parameter to match the pattern
+        when(mockRun.getAction(ParametersAction.class)).thenReturn(paramsAction);
+        when(paramsAction.getParameter(paramName)).thenReturn(parameterValue);
+        when(parameterValue.getValue()).thenReturn(paramValue);
+
+        // Call the method directly through reflection to test just that method
+        try {
+            java.lang.reflect.Method method = BuildParameterRunSelectorExtension.class.getDeclaredMethod(
+                    "matchRule", Job.class, Run.class, String.class);
+            method.setAccessible(true);
+            BuildParameterRunSelectorExtension extension = new BuildParameterRunSelectorExtension();
+            Boolean result =
+                    (Boolean) method.invoke(extension, mockProject, mockRun, "params." + paramName + "=" + paramValue);
+            assertThat(result, is(true));
+        } catch (Exception e) {
+            // Just log the exception and fail the test
+            System.err.println("Failed to invoke matchRule method: " + e.getMessage());
+            assertThat("Test should not fail with exception", false);
+        }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterRunSelectorExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterRunSelectorExtensionTest.java
@@ -592,7 +592,7 @@ class BuildParameterRunSelectorExtensionTest {
     }
 
     @Test
-    void shouldMatchParameterValueWithSpecificPattern() {
+    void shouldMatchParameterValueWithSpecificPattern() throws Exception {
         // Test the parameter matching pattern
         String paramName = "branch";
         String paramValue = "master";
@@ -607,18 +607,12 @@ class BuildParameterRunSelectorExtensionTest {
         when(parameterValue.getValue()).thenReturn(paramValue);
 
         // Call the method directly through reflection to test just that method
-        try {
-            java.lang.reflect.Method method = BuildParameterRunSelectorExtension.class.getDeclaredMethod(
-                    "matchRule", Job.class, Run.class, String.class);
-            method.setAccessible(true);
-            BuildParameterRunSelectorExtension extension = new BuildParameterRunSelectorExtension();
-            Boolean result =
-                    (Boolean) method.invoke(extension, mockProject, mockRun, "params." + paramName + "=" + paramValue);
-            assertThat(result, is(true));
-        } catch (Exception e) {
-            // Just log the exception and fail the test
-            System.err.println("Failed to invoke matchRule method: " + e.getMessage());
-            assertThat("Test should not fail with exception", false);
-        }
+        java.lang.reflect.Method method = BuildParameterRunSelectorExtension.class.getDeclaredMethod(
+                "matchRule", Job.class, Run.class, String.class);
+        method.setAccessible(true);
+        BuildParameterRunSelectorExtension extension = new BuildParameterRunSelectorExtension();
+        Boolean result =
+                (Boolean) method.invoke(extension, mockProject, mockRun, "params." + paramName + "=" + paramValue);
+        assertThat(result, is(true));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterRunSelectorExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/extensions/BuildParameterRunSelectorExtensionTest.java
@@ -178,8 +178,7 @@ class BuildParameterRunSelectorExtensionTest {
         when(mockParametersAction2.getParameter(paramName)).thenReturn(matchingParameterValue);
 
         Run actualRun = extension.select(mockProject, "last:${" + rule + "}", null);
-        // It should have skipped the first run due to non-matching parameter
-        // and found the second run which does match
+        // It should have skipped the first run due to non-matching parameter and found the second run which does match
         assertThat(actualRun, is(mockRun2));
     }
 
@@ -273,8 +272,7 @@ class BuildParameterRunSelectorExtensionTest {
 
         // For an invalid rule, all runs should be considered without parameter matching
         Run actualRun = extension.select(mockProject, "last:" + invalidRule, null);
-        // We should get the first run because the invalid rule doesn't force parameter
-        // matching
+        // We should get the first run because the invalid rule doesn't force parameter matching
         assertThat(actualRun, is(mockRun));
     }
 
@@ -307,8 +305,7 @@ class BuildParameterRunSelectorExtensionTest {
 
     @Test
     void shouldHandleRunWithNullResult() {
-        // For the "lastFailed" case, the implementation first checks
-        // job.getLastFailedBuild()
+        // For the "lastFailed" case, the implementation first checks job.getLastFailedBuild()
         // So we need to mock this behavior
         when(mockProject.getLastFailedBuild()).thenReturn(mockRun);
 
@@ -376,8 +373,7 @@ class BuildParameterRunSelectorExtensionTest {
 
     @Test
     void shouldHandleInvalidParameterRule() {
-        // For an invalid parameter rule, we need to ensure it's actually in the ${}
-        // format
+        // For an invalid parameter rule, we need to ensure it's actually in the ${} format
         // but with invalid content inside that doesn't match params.x=y pattern
         String invalidRule = "someInvalidContent";
 
@@ -389,8 +385,7 @@ class BuildParameterRunSelectorExtensionTest {
 
     @Test
     void shouldHandleCompletedBuildCriteria() {
-        // For firstCompleted, we need to set up the lastCompletedBuild mock since
-        // that's what
+        // For firstCompleted, we need to set up the lastCompletedBuild mock since that's what
         // the actual implementation of BuildParameterRunSelectorExtension is using
         when(mockProject.getLastCompletedBuild()).thenReturn(mockRun);
         Run actualRun = extension.select(mockProject, "lastCompleted", null);
@@ -576,8 +571,7 @@ class BuildParameterRunSelectorExtensionTest {
         when(run2.getResult()).thenReturn(Result.UNSTABLE); // Unstable result
         when(run3.getResult()).thenReturn(Result.SUCCESS); // Success result
 
-        // Test finding different specific types - but use the project.getLastXXX
-        // methods
+        // Test finding different specific types - but use the project.getLastXXX methods
         when(mockProject.getLastUnstableBuild()).thenReturn(run2);
         when(mockProject.getLastSuccessfulBuild()).thenReturn(run3);
 


### PR DESCRIPTION
### Improved test coverage of org.jenkinsci.plugins.badge.extensions (from 86% to 96%)

[JENKINS-70464](https://issues.jenkins.io/browse/JENKINS-70464?jql=labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20%22To%20Do%22%2C%20Reopened))

### Before
![Screenshot 2025-04-05 102838](https://github.com/user-attachments/assets/6d1d52f5-583d-4466-8964-a1764d1d6ad2)
### After
![Screenshot 2025-03-30 222808](https://github.com/user-attachments/assets/7bf36c16-64da-4201-92de-e4674ab156b6)



### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
