### PR TITLE
Improve font loading performance

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
@@ -211,32 +211,46 @@ class StatusImage implements HttpResponse {
         }
     }
 
-    private static final FontMetrics DEFAULT_FONT_METRICS;
+    private static volatile FontMetrics cachedFontMetrics;
+    private static final Object fontLoadLock = new Object();
+    private static final String FONT_NAME = "fonts/Bitstream-Vera-Sans-Roman.ttf";
 
-    static {
-        Font defaultFont = null;
-        final String FONT_NAME = "fonts/Bitstream-Vera-Sans-Roman.ttf";
-        try {
-            URL fontURL = new URL(baseUrl, FONT_NAME);
-            try (InputStream fontStream = fontURL.openStream()) {
-                defaultFont = Font.createFont(Font.TRUETYPE_FONT, fontStream);
-                defaultFont = defaultFont.deriveFont(11f);
-            } catch (FontFormatException ex) {
-                Logger.getLogger(StatusImage.class.getName())
-                        .log(Level.SEVERE, "Font format exception " + FONT_NAME, ex);
-            } catch (IOException ex) {
-                Logger.getLogger(StatusImage.class.getName()).log(Level.SEVERE, "IOException reading " + FONT_NAME, ex);
+    private static FontMetrics getDefaultFontMetrics() {
+        if (cachedFontMetrics == null) {
+            synchronized (fontLoadLock) {
+                if (cachedFontMetrics == null) {
+                    Font defaultFont = null;
+                    try {
+                        if (baseUrl != null) {
+                            URL fontURL = new URL(baseUrl, FONT_NAME);
+                            try (InputStream fontStream = fontURL.openStream()) {
+                                defaultFont = Font.createFont(Font.TRUETYPE_FONT, fontStream);
+                                defaultFont = defaultFont.deriveFont(11f);
+                            } catch (FontFormatException ex) {
+                                LOGGER.log(Level.SEVERE, "Font format exception " + FONT_NAME, ex);
+                            } catch (IOException ex) {
+                                LOGGER.log(Level.SEVERE, "IOException reading " + FONT_NAME, ex);
+                            }
+                        }
+                    } catch (MalformedURLException ex) {
+                        LOGGER.log(Level.SEVERE, "Malformed URL on static font " + FONT_NAME, ex);
+                    }
+
+                    // Fallback to system default font if custom font loading fails
+                    if (defaultFont == null) {
+                        defaultFont = new Font(Font.SANS_SERIF, Font.PLAIN, 11);
+                    }
+
+                    Canvas canvas = new Canvas();
+                    cachedFontMetrics = canvas.getFontMetrics(defaultFont);
+                }
             }
-        } catch (MalformedURLException ex) {
-            Logger.getLogger(StatusImage.class.getName())
-                    .log(Level.SEVERE, "Malformed URL on static font " + FONT_NAME, ex);
         }
-        Canvas canvas = new Canvas();
-        DEFAULT_FONT_METRICS = canvas.getFontMetrics(defaultFont);
+        return cachedFontMetrics;
     }
 
     public int measureText(String text) throws IOException {
-        return baseUrl != null ? DEFAULT_FONT_METRICS.stringWidth(text) : 0;
+        return baseUrl != null ? getDefaultFontMetrics().stringWidth(text) : 0;
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -301,6 +301,8 @@ class StatusImageTest {
         // Test thread safety of font loading mechanism
         final int threadCount = 10;
         final String testText = "Concurrent Test " + RANDOM.nextInt();
+        final int textWidth = new StatusImage().measureText(testText);
+        assertThat(textWidth, is(greaterThan(5 * testText.length())));
         final CountDownLatch startLatch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(threadCount);
         final AtomicReference<Exception> exception = new AtomicReference<>();
@@ -317,10 +319,8 @@ class StatusImageTest {
 
                         StatusImage statusImage = new StatusImage();
                         int width = statusImage.measureText(testText);
-
-                        if (width > 0) {
-                            successCount.incrementAndGet();
-                        }
+                        assertThat(width, is(textWidth));
+                        successCount.incrementAndGet();
                     } catch (Exception e) {
                         exception.set(e);
                     } finally {
@@ -333,9 +333,7 @@ class StatusImageTest {
 
             boolean completed = doneLatch.await(10, TimeUnit.SECONDS);
             assertThat("All threads should complete within timeout", completed, is(true));
-
             assertThat("Exception thrown during thread test", exception.get(), is(nullValue()));
-
             assertThat("All threads should succeed in measuring text", successCount.get(), is(threadCount));
 
         } finally {
@@ -367,24 +365,6 @@ class StatusImageTest {
         for (String input : testInputs) {
             int width = statusImage.measureText(input);
             assertThat("Insufficient width for input: " + input, width, greaterThan(input.length() * 5));
-        }
-    }
-
-    @Test
-    void testFontLoadingCaching() throws Exception {
-        // Test that font metrics are properly cached and reused
-        StatusImage statusImage = new StatusImage();
-
-        String testText = "Caching Test " + RANDOM.nextInt();
-        int referenceMeasurement = statusImage.measureText(testText);
-
-        // Make multiple calls and verify they're consistent (indicating caching is working)
-        // All measurements should be identical if caching is working
-        for (int i = 5 + RANDOM.nextInt(10); i > 0; i--) {
-            assertThat(
-                    "Measurement " + i + " does not match reference",
-                    statusImage.measureText(testText),
-                    is(referenceMeasurement));
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -106,7 +106,7 @@ class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(920), lessThan(960)));
+        assertThat(Integer.valueOf(statusImage.getLength()), allOf(greaterThan(920), lessThan(960)));
     }
 
     @Test
@@ -124,7 +124,7 @@ class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
+        assertThat(Integer.valueOf(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
     }
 
     @Test
@@ -143,7 +143,7 @@ class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(animatedColorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(1237), lessThan(1297)));
+        assertThat(Integer.valueOf(statusImage.getLength()), allOf(greaterThan(1237), lessThan(1297)));
     }
 
     @Test
@@ -162,7 +162,7 @@ class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(animatedColorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(1237), lessThan(1297)));
+        assertThat(Integer.valueOf(statusImage.getLength()), allOf(greaterThan(1237), lessThan(1297)));
     }
 
     @Test
@@ -181,7 +181,7 @@ class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(animatedColorName));
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(1237), lessThan(1297)));
+        assertThat(Integer.valueOf(statusImage.getLength()), allOf(greaterThan(1237), lessThan(1297)));
     }
 
     @Test
@@ -199,7 +199,7 @@ class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
+        assertThat(Integer.valueOf(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
     }
 
     @Test
@@ -217,7 +217,7 @@ class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
+        assertThat(Integer.valueOf(statusImage.getLength()), allOf(greaterThan(973), lessThan(1033)));
     }
 
     @Test
@@ -235,7 +235,7 @@ class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(510), lessThan(540)));
+        assertThat(Integer.valueOf(statusImage.getLength()), allOf(greaterThan(510), lessThan(540)));
     }
 
     @Test
@@ -253,7 +253,7 @@ class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(style));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(510), lessThan(540)));
+        assertThat(Integer.valueOf(statusImage.getLength()), allOf(greaterThan(510), lessThan(540)));
     }
 
     @Test
@@ -270,7 +270,7 @@ class StatusImageTest {
         assertThat(statusImage.getEtag(), containsString(colorName));
         assertThat(statusImage.getEtag(), containsString("null"));
         assertThat(statusImage.getContentType(), is(SVG_CONTENT_TYPE));
-        assertThat(Integer.parseInt(statusImage.getLength()), allOf(greaterThan(875), lessThan(925)));
+        assertThat(Integer.valueOf(statusImage.getLength()), allOf(greaterThan(875), lessThan(925)));
     }
 
     // private static final String PNG_CONTENT_TYPE = "image/png";
@@ -281,7 +281,7 @@ class StatusImageTest {
         StatusImage statusImage = new StatusImage(fileName);
         assertThat(statusImage.getEtag(), containsString(fileName));
         // assertThat(statusImage.getContentType(), is(PNG_CONTENT_TYPE));
-        assertThat(statusImage.getLength(), is("1656"));
+        assertThat(Integer.valueOf(statusImage.getLength()), is(1656));
     }
 
     @Test
@@ -290,7 +290,7 @@ class StatusImageTest {
         StatusImage statusImage = new StatusImage(fileName);
         assertThat(statusImage.getEtag(), containsString(fileName));
         // assertThat(statusImage.getContentType(), is(PNG_CONTENT_TYPE));
-        assertThat(statusImage.getLength(), is("656"));
+        assertThat(Integer.valueOf(statusImage.getLength()), is(656));
     }
 
     // ========================================================================

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.lang.reflect.Field;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -48,6 +49,7 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 class StatusImageTest {
 
     private static final String SVG_CONTENT_TYPE = "image/svg+xml;charset=utf-8";
+    private static final Random RANDOM = new Random();
 
     @SuppressWarnings("unused")
     private static JenkinsRule jenkinsRule;
@@ -340,7 +342,7 @@ class StatusImageTest {
     void testConcurrentFontLoading() throws Exception {
         // Test thread safety of font loading mechanism
         final int threadCount = 10;
-        final String testText = "Concurrent Test";
+        final String testText = "Concurrent Test " + RANDOM.nextInt();
         final CountDownLatch startLatch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(threadCount);
         final AtomicReference<Exception> exception = new AtomicReference<>();

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -299,7 +299,7 @@ class StatusImageTest {
     @Test
     void testConcurrentFontLoading() throws Exception {
         // Test thread safety of font loading mechanism
-        final int threadCount = 10;
+        final int threadCount = 10 + RANDOM.nextInt(10);
         final String testText = "Concurrent Test " + RANDOM.nextInt();
         final int textWidth = new StatusImage().measureText(testText);
         assertThat(textWidth, is(greaterThan(5 * testText.length())));
@@ -317,9 +317,7 @@ class StatusImageTest {
                     try {
                         startLatch.await(); // Wait for all threads to be ready
 
-                        StatusImage statusImage = new StatusImage();
-                        int width = statusImage.measureText(testText);
-                        assertThat(width, is(textWidth));
+                        assertThat(new StatusImage().measureText(testText), is(textWidth));
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         exception.set(e);

--- a/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/badge/StatusImageTest.java
@@ -296,48 +296,6 @@ class StatusImageTest {
     // ========================================================================
     // Font Loading Tests - Added for performance fix verification
     // ========================================================================
-
-    @Test
-    void testFontLoadingFallbackBehavior() throws Exception {
-        // Test that measureText works even when custom font loading might fail
-        // This implicitly tests the fallback to system font mechanism
-        StatusImage statusImage = new StatusImage();
-
-        // These calls should work regardless of whether custom font loading succeeds
-        int width = statusImage.measureText("Test");
-        assertThat("Text measurement should return positive width", width, greaterThan(0));
-
-        // Multiple calls should be consistent (testing caching)
-        int width2 = statusImage.measureText("Test");
-        assertThat("Multiple calls should return same width", width2, is(width));
-    }
-
-    @Test
-    void testFontLoadingLaziness() throws Exception {
-        // Test that font loading is lazy - font should only be loaded when measureText is called
-        StatusImage statusImage = new StatusImage(); // Constructor should not trigger font loading
-
-        // First call should trigger font loading and return valid measurement
-        int width1 = statusImage.measureText("W");
-        assertThat("First measureText call should work", width1, greaterThan(0));
-
-        // Second call should use cached font and return same measurement
-        int width2 = statusImage.measureText("W");
-        assertThat("Second measureText call should return same width", width2, is(width1));
-    }
-
-    @Test
-    void testFontLoadingConsistency() throws Exception {
-        // Test that font loading produces consistent results across different StatusImage instances
-        StatusImage statusImage1 = new StatusImage();
-        StatusImage statusImage2 = new StatusImage();
-
-        int width1 = statusImage1.measureText("Consistency Test");
-        int width2 = statusImage2.measureText("Consistency Test");
-
-        assertThat("Font measurements should be consistent across instances", width2, is(width1));
-    }
-
     @Test
     void testConcurrentFontLoading() throws Exception {
         // Test thread safety of font loading mechanism
@@ -417,35 +375,16 @@ class StatusImageTest {
         // Test that font metrics are properly cached and reused
         StatusImage statusImage = new StatusImage();
 
+        String testText = "Caching Test " + RANDOM.nextInt();
+        int referenceMeasurement = statusImage.measureText(testText);
+
         // Make multiple calls and verify they're consistent (indicating caching is working)
-        String testText = "Caching Test";
-        int[] measurements = new int[5];
-
-        for (int i = 0; i < measurements.length; i++) {
-            measurements[i] = statusImage.measureText(testText);
-        }
-
         // All measurements should be identical if caching is working
-        for (int i = 1; i < measurements.length; i++) {
-            assertThat("Cached measurements should be consistent", measurements[i], is(measurements[0]));
+        for (int i = 5 + RANDOM.nextInt(10); i > 0; i--) {
+            assertThat(
+                    "Measurement " + i + " does not match reference",
+                    statusImage.measureText(testText),
+                    is(referenceMeasurement));
         }
-    }
-
-    @Test
-    void testMultipleInstancesFontSharing() throws Exception {
-        // Test that multiple StatusImage instances share the same cached font
-        final String testText = "Shared Font Test";
-
-        StatusImage statusImage1 = new StatusImage();
-        int width1 = statusImage1.measureText(testText);
-
-        StatusImage statusImage2 = new StatusImage();
-        int width2 = statusImage2.measureText(testText);
-
-        StatusImage statusImage3 = new StatusImage();
-        int width3 = statusImage3.measureText(testText);
-
-        assertThat("All instances should use same cached font", width2, is(width1));
-        assertThat("All instances should use same cached font", width3, is(width1));
     }
 }


### PR DESCRIPTION
Fixes a performance issue where font loading in StatusImage was blocking all threads during class initialization. 

Replaces the static initializer with thread-safe lazy loading and adds comprehensive test coverage.

### Testing done

* `mvn clean verify`
* `mvn hpi:run` for interactive testing

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed