### PR TITLE
Modernize with Java 17 features and improve performance

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/EmbeddableBadgeConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/EmbeddableBadgeConfig.java
@@ -6,7 +6,6 @@ package org.jenkinsci.plugins.badge;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
@@ -14,18 +13,12 @@ public class EmbeddableBadgeConfig implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private final Map<String, String> colors = new HashMap<>() {
-        @Serial
-        private static final long serialVersionUID = 1L;
-
-        {
-            put("failing", "red");
-            put("passing", "brightgreen");
-            put("unstable", "yellow");
-            put("aborted", "aborted");
-            put("running", "blue");
-        }
-    };
+    private static final Map<String, String> COLORS = Map.of(
+            "failing", "red",
+            "passing", "brightgreen",
+            "unstable", "yellow",
+            "aborted", "aborted",
+            "running", "blue");
 
     private final String id;
     private String subject = null;
@@ -62,7 +55,7 @@ public class EmbeddableBadgeConfig implements Serializable {
 
     public String getColor() {
         if (color == null) {
-            return colors.get(status);
+            return status != null ? COLORS.get(status) : null;
         }
         return color;
     }

--- a/src/main/java/org/jenkinsci/plugins/badge/ImageResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/ImageResolver.java
@@ -25,23 +25,17 @@ package org.jenkinsci.plugins.badge;
 
 import hudson.model.BallColor;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 public class ImageResolver {
-    private final Map<String, String> statuses = new HashMap<>() {
-        private static final long serialVersionUID = 1L;
-
-        {
-            put("red", "failing");
-            put("brightgreen", "passing");
-            put("yellow", "unstable");
-            put("aborted", "aborted");
-            put("blue", "running");
-            put("disabled", "disabled");
-            put("notbuilt", "not run");
-        }
-    };
+    private static final Map<String, String> STATUSES = Map.of(
+            "red", "failing",
+            "brightgreen", "passing",
+            "yellow", "unstable",
+            "aborted", "aborted",
+            "blue", "running",
+            "disabled", "disabled",
+            "notbuilt", "not run");
 
     public StatusImage getImage(
             BallColor color,
@@ -101,7 +95,7 @@ public class ImageResolver {
         }
 
         if (status == null) {
-            status = statuses.get(
+            status = STATUSES.get(
                     statusAnimatedOverlayColorName != null ? statusAnimatedOverlayColorName : statusColorName);
             if (status == null) {
                 status = "unknown";

--- a/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
@@ -19,7 +19,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -60,20 +59,15 @@ class StatusImage implements HttpResponse {
     private final String length;
     private String contentType = null;
 
-    private final Map<String, String> colors = new HashMap<>() {
-        private static final long serialVersionUID = 1L;
-
-        {
-            put("red", "#e05d44");
-            put("brightgreen", "#44cc11");
-            put("green", "#97CA00");
-            put("yellowgreen", "#a4a61d");
-            put("yellow", "#dfb317");
-            put("orange", "#fe7d37");
-            put("lightgrey", "#9f9f9f");
-            put("blue", "#007ec6");
-        }
-    };
+    private static final Map<String, String> COLORS = Map.of(
+            "red", "#e05d44",
+            "brightgreen", "#44cc11",
+            "green", "#97CA00",
+            "yellowgreen", "#a4a61d",
+            "yellow", "#dfb317",
+            "orange", "#fe7d37",
+            "lightgrey", "#9f9f9f",
+            "blue", "#007ec6");
 
     StatusImage() {
         etag = '"' + Jenkins.RESOURCE_PATH + '/' + "empty" + '"';
@@ -128,7 +122,7 @@ class StatusImage implements HttpResponse {
 
             if (animatedColorName != null) {
                 animatedSnippet = new URL(baseUrl, "status/animatedOverlay.svg.snippet");
-                animatedColor = colors.get(animatedColorName.toLowerCase());
+                animatedColor = COLORS.get(animatedColorName.toLowerCase());
                 if (animatedColor == null) {
                     if (colorName.matches("-?[0-9a-fA-F]+")) {
                         animatedColor = "#" + animatedColorName;
@@ -144,7 +138,7 @@ class StatusImage implements HttpResponse {
                 widths[1] += 4;
             }
 
-            String color = colors.get(colorName.toLowerCase());
+            String color = COLORS.get(colorName.toLowerCase());
             if (color == null) {
                 if (colorName.matches("-?[0-9a-fA-F]+")) {
                     color = "#" + colorName;


### PR DESCRIPTION
- Modernize collection initialization using Java 17's `Map.of()` for better performance
- Convert instance-level HashMap initializers to static final immutable maps
- Add proper null safety handling for immutable map usage

### Testing done

- `mvn clean verify`
- manual testing

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed