### PR TITLE
Fix JS and CSS loading

### DIFF
--- a/src/main/resources/components/builder.jelly
+++ b/src/main/resources/components/builder.jelly
@@ -9,8 +9,8 @@
     <j:set var="publicText"  value="${app.rootUrl}buildStatus/text?job=${fullJobName}"/>
 
     <l:header>
-      <script src="${app.rootUrl}/plugin/embeddable-build-status/css/builder.js" type="text/javascript" defer="true" />
-      <link rel='stylesheet' href='${app.rootUrl}/plugin/embeddable-build-status/css/design.css' type='text/css'/>
+      <script src="${rootURL}/plugin/embeddable-build-status/css/builder.js" type="text/javascript" defer="true" />
+      <link rel='stylesheet' href='${rootURL}/plugin/embeddable-build-status/css/design.css' type='text/css'/>
     </l:header>
 
     <l:main-panel>


### PR DESCRIPTION
Ran the plugin in my instance of Jenkins - noticed the JS and CSS were 404ing, very odd considering when running the plugin itself it worked fine.

Changing from `app.rootUrl` to `rootURL` works for me.

**Before**
<img width="1728" height="607" alt="Screenshot 2025-10-18 at 18 50 04" src="https://github.com/user-attachments/assets/233238b7-9115-453e-9ffd-aeb60f9f4044" />

**After**
<img width="1726" height="545" alt="image" src="https://github.com/user-attachments/assets/03cf7def-8b73-4648-adfe-17bc10272bea" />


### Testing done

* JS and CSS loads

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
