### PR TITLE
[JENKINS-74745] Make `?link` attribute work when CSP is enforced

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java
@@ -153,7 +153,8 @@ class StatusImage implements HttpResponse {
             String subjectPos = String.valueOf((widths[0] / 2) + 1);
             String statusPos = String.valueOf(widths[0] + (widths[1] / 2) - 1);
             String animatedOverlay = "";
-            String linkCode = "<svg xmlns";
+            String linkStart = "";
+            String linkEnd = "";
 
             // first: add animated overlay
             if (animatedSnippet != null) {
@@ -170,9 +171,8 @@ class StatusImage implements HttpResponse {
                     URL url = new URL(link);
                     final String protocol = url.getProtocol();
                     if ("http".equals(protocol) || "https".equals(protocol)) {
-                        linkCode = "<svg onclick=\"window.open(&quot;"
-                                + link
-                                + "&quot;);\" style=\"cursor: pointer;\" xmlns";
+                        linkStart = "<a href=\"" + link + "\" target=\"_blank\">";
+                        linkEnd = "</a>";
                     } else {
                         LOGGER.log(Level.FINE, "Invalid link protocol: {0}", protocol);
                     }
@@ -192,7 +192,8 @@ class StatusImage implements HttpResponse {
                         .replace("{{subject}}", subject)
                         .replace("{{status}}", status)
                         .replace("{{color}}", color)
-                        .replace("<svg xmlns", linkCode)
+                        .replace("{{linkStart}}", linkStart)
+                        .replace("{{linkEnd}}", linkEnd)
                         .getBytes(StandardCharsets.UTF_8);
             }
 

--- a/src/main/webapp/status/flat-square.svg
+++ b/src/main/webapp/status/flat-square.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="{{fullwidth}}" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="{{fullwidth}}" height="20">{{linkStart}}
     <rect rx="0" width="{{fullwidth}}" height="20" fill="#555"/>
     <rect rx="0" x="{{subjectWidth}}" width="{{statusWidth}}" height="20" fill="{{color}}"/>
     {{animatedOverlayColor}}
@@ -7,5 +7,5 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="{{subjectPos}}" y="14">{{subject}}</text>
         <text x="{{statusPos}}" y="14">{{status}}</text>
-    </g>
+    </g>{{linkEnd}}
 </svg>

--- a/src/main/webapp/status/flat.svg
+++ b/src/main/webapp/status/flat.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="{{fullwidth}}" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="{{fullwidth}}" height="20">{{linkStart}}
     <linearGradient id="a" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -14,5 +14,5 @@
         <text x="{{subjectPos}}" y="14">{{subject}}</text>
         <text x="{{statusPos}}" y="15" fill="#010101" fill-opacity=".3">{{status}}</text>
         <text x="{{statusPos}}" y="14">{{status}}</text>
-    </g>
+    </g>{{linkEnd}}
 </svg>

--- a/src/main/webapp/status/plastic.svg
+++ b/src/main/webapp/status/plastic.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="{{fullwidth}}" height="18">
+<svg xmlns="http://www.w3.org/2000/svg" width="{{fullwidth}}" height="18">{{linkStart}}
     <linearGradient id="a" x2="0" y2="100%">
         <stop offset="0" stop-color="#fff" stop-opacity=".7" />
         <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
@@ -16,5 +16,5 @@
         <text x="{{subjectPos}}" y="13">{{subject}}</text>
         <text x="{{statusPos}}" y="14" fill="#010101" fill-opacity=".3">{{status}}</text>
         <text x="{{statusPos}}" y="13">{{status}}</text>
-    </g>
+    </g>{{linkEnd}}
 </svg>


### PR DESCRIPTION
[JENKINS-74745](https://issues.jenkins.io/browse/JENKINS-74745)

This removes the inline JS in favor of an `a` link. This link works even when Jenkins 2.539+ enforces Content Security Policy, prohibiting inline scripts.

https://github.com/jenkinsci/embeddable-build-status-plugin/issues/457 discusses problems with the feature as it currently exists, so it's not clear to me what the supported use cases are. If the use case is indeed showing the image in an `iframe`, _this PR will not help_, unless administrators use https://plugins.jenkins.io/csp/ to relax the `frame-ancestors` directive (which is still better than having to allow `script-src 'unsafe-inline'` though).

### Testing done

Accessed the image URL directly. With valid `?link` value, click opens new tab. Without, no link. With and without CSP enforcement.

In an `iframe`, without CSP enforcing `frame-ancestors`, it also works.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
