### PR TITLE
Ban deprecated stapler imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
-    <ban-deprecated-stapler.skip>true</ban-deprecated-stapler.skip>
+    <ban-deprecated-stapler.skip>false</ban-deprecated-stapler.skip>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Ban deprecated stapler imports

From plugin pom pull request:

* https://github.com/jenkinsci/plugin-pom/pull/1378

### Testing done

* Confirmed compilation still succeeds

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
