### PR TITLE
Require Jenkins 2.528.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.baseline>2.528</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/JobBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/JobBadgeAction.java
@@ -71,9 +71,6 @@ public class JobBadgeAction implements Action, IconSpec {
         if (project == null) {
             return "null-project-no-url-encoded-fullName";
         }
-        if (project.getFullName() == null) {
-            return "null-project-fullName-no-url-encoded-fullName";
-        }
         String fullName = URLEncoder.encode(project.getFullName(), StandardCharsets.UTF_8);
         return fullName == null ? "null-url-encoded-fullName" : fullName;
     }

--- a/src/main/java/org/jenkinsci/plugins/badge/actions/RunBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/actions/RunBadgeAction.java
@@ -70,9 +70,6 @@ public class RunBadgeAction implements Action, IconSpec {
         if (project == null) {
             return "null-project-no-url-encoded-fullName";
         }
-        if (project.getFullName() == null) {
-            return "null-project-fullName-no-url-encoded-fullName";
-        }
         String fullName = URLEncoder.encode(project.getFullName(), StandardCharsets.UTF_8);
         return fullName == null ? "null-url-encoded-fullName" : fullName;
     }


### PR DESCRIPTION
## Require Jenkins 2.528.3 or newer

Core security advisories have been issued for versions before 2.528.3 and "Choosing a Jenkins version to build against" recommends 2.528.3 as the minimum version.

Tests "update plugin BOM and close pull request if it passes".  Pull request:

* https://github.com/jenkinsci/embeddable-build-status-plugin/pull/537

### Testing done

* Confirmed that automated tests pass on Linux with Java 21

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
